### PR TITLE
fix for issue #53 gulp less to css output filename

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ elixir(function(mix) {
 
         .less([ // Process front-end stylesheets
             'frontend/main.less'
-        ], 'resources/assets/css/frontend/main.less')
+        ], 'resources/assets/css/frontend/main.css')
         .styles([  // Combine pre-processed CSS files
             'frontend/main.css'
         ], 'public/css/frontend.css')


### PR DESCRIPTION
Fixes bugg with **Gulp** less compilation where the output file name was `main.less` instead of `main.css` in **gulpfile.js**

I am a less lover and for that I am proud, @rappasoft 
:wink: 