### PR TITLE
Added sv translation to backend/welcome.blade.php

### DIFF
--- a/resources/views/backend/lang/sv/welcome.blade.php
+++ b/resources/views/backend/lang/sv/welcome.blade.php
@@ -1,1 +1,8 @@
-<p>Svenska</p>
+<p>Detta är AdminLTE temat av <a href="https://almsaeedstudio.com/" target="_blank">https://almsaeedstudio.com/</a>.
+Detta är en avskalad version med enbart de mest nödvändiga stilmallarna och skripten för att få det att fungera.
+Ladda ner den fulla versionen och börja lägg till de komponenter du behöver.</p>
+<p>Alla länkar/funktioner är här är bara exempel förutom <strong>Hantera användare</strong> i sidomenyn
+Denna boilerplate kommer med fullt funktionerande <em>Access Control Library</em> för att hantera användare/roller/rättigheter.</p>
+<p>Tänk på att detta repo fortfarande byggs och att det kan förekomma buggar och fel som inte upptäckts. Jag ska göra mitt bästa för att förebygga detta.</p>
+<p>Hoppas att du tycker om detta projekt som jag lagt ner så mycket tid i. Besök repots <a href="https://github.com/rappasoft/laravel-5-boilerplate" target="_blank">GitHub</a> för att få mer information och rapportera gärna dina tankar/fel som <a href="https://github.com/rappasoft/Laravel-5-Boilerplate/issues" target="_blank">issues här</a>.</p>
+<p>- Anthony Rappa</p>


### PR DESCRIPTION
I actually had this one sitting in my other project but forgot to include it. I only thought of `resources/lang` how come that it is in `backend/lang`?

Would be nice to add it into  `resources/lang`  instead? Make it an `welcome.php` language file instead of blade as of now? It would still be possible to insert the links to your site and the github repo. 
````
//welcome.php
Blah bla bla :link-to-rappa-website bla ...... bla :link-to-github bla bla
````
That way keep it all in one place?