### PR TITLE
Active state log viewer dropdown sidebar

### DIFF
--- a/resources/views/backend/includes/sidebar.blade.php
+++ b/resources/views/backend/includes/sidebar.blade.php
@@ -37,14 +37,18 @@
                   <li class="{{ Active::pattern('admin/access/*') }}"><a href="{!!url('admin/access/users')!!}"><span>{{ trans('menus.access_management') }}</span></a></li>
                 @endif
 
-                <li class="{{ Active::pattern('admin/log-viewer/*') }} treeview">
+                 <li class="{{ Active::pattern('admin/log-viewer*') }} treeview">
                   <a href="#">
                     <span>{{ trans('menus.log-viewer.main') }}</span>
                     <i class="fa fa-angle-left pull-right"></i>
                   </a>
-                  <ul class="treeview-menu" style="display: none;">
-                    <li><a href="{!! url('admin/log-viewer') !!}">{{ trans('menus.log-viewer.dashboard') }}</a></li>
-                    <li><a href="{!! url('admin/log-viewer/logs') !!}">{{ trans('menus.log-viewer.logs') }}</a></li>
+                  <ul class="treeview-menu {{ Active::pattern('admin/log-viewer*', 'menu-open') }}" style="display: none; {{ Active::pattern('admin/log-viewer*', 'display: block;') }}">
+                    <li class="{{ Active::pattern('admin/log-viewer') }}">
+                      <a href="{!! url('admin/log-viewer') !!}">{{ trans('menus.log-viewer.dashboard') }}</a>
+                    </li>
+                    <li class="{{ Active::pattern('admin/log-viewer/logs') }}">
+                      <a href="{!! url('admin/log-viewer/logs') !!}">{{ trans('menus.log-viewer.logs') }}</a>
+                    </li>
                   </ul>
                 </li>
 

--- a/resources/views/backend/lang/sv/welcome.blade.php
+++ b/resources/views/backend/lang/sv/welcome.blade.php
@@ -1,1 +1,8 @@
-<p>Svenska</p>
+<p>Detta är AdminLTE temat av <a href="https://almsaeedstudio.com/" target="_blank">https://almsaeedstudio.com/</a>.
+Detta är en avskalad version med enbart de mest nödvändiga stilmallarna och skripten för att få det att fungera.
+Ladda ner den fulla versionen och börja lägg till de komponenter du behöver.</p>
+<p>Alla länkar/funktioner är här är bara exempel förutom <strong>Hantera användare</strong> i sidomenyn
+Denna boilerplate kommer med fullt funktionerande <em>Access Control Library</em> för att hantera användare/roller/rättigheter.</p>
+<p>Tänk på att detta repo fortfarande byggs och att det kan förekomma buggar och fel som inte upptäckts. Jag ska göra mitt bästa för att förebygga detta.</p>
+<p>Hoppas att du tycker om detta projekt som jag lagt ner så mycket tid i. Besök repots <a href="https://github.com/rappasoft/laravel-5-boilerplate" target="_blank">GitHub</a> för att få mer information och rapportera gärna dina tankar/fel som <a href="https://github.com/rappasoft/Laravel-5-Boilerplate/issues" target="_blank">issues här</a>.</p>
+<p>- Anthony Rappa</p>


### PR DESCRIPTION
So now if you click *Log Viewer -> Dashboard* the dropdown will stay open and *Dashboard* get an `active` state.
Ofc also works for `/admin/log-viewer/logs`


<img width="1326" alt="skarmavbild 2015-09-22 kl 12 53 43" src="https://cloud.githubusercontent.com/assets/10044093/10016809/d2192302-6129-11e5-8957-ad1d26a84fc8.png">
