### PR TITLE
Typo that causes composer to crash on Linux systems

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -164,7 +164,7 @@ return [
 		'Arcanedev\LogViewer\LogViewerServiceProvider',
 		'Creativeorange\Gravatar\GravatarServiceProvider',
 		'HieuLe\Active\ActiveServiceProvider',
-		'Laracasts\Utilities\JavaScript\JavascriptServiceProvider',
+		'Laracasts\Utilities\JavaScript\JavaScriptServiceProvider',
 		'Laravel\Socialite\SocialiteServiceProvider',
 		'Potsky\LaravelLocalizationHelpers\LaravelLocalizationHelpersServiceProviderLaravel5',
 	],


### PR DESCRIPTION
Note the "S" majuscule :)