### PR TITLE
Prevent user login with social account if banned or deactivate

### DIFF
--- a/app/Http/Controllers/Frontend/Auth/PasswordController.php
+++ b/app/Http/Controllers/Frontend/Auth/PasswordController.php
@@ -52,6 +52,9 @@ class PasswordController extends Controller {
      */
 	public function postEmail(Request $request)
 	{
+		// First of all check if the input is a valid email
+		$this->validate($request, ['email' => 'required|email']);
+		
 		//Make sure user is confirmed before resetting password.
 		$user = User::where('email', $request->get('email'))->first();
 		if ($user) {
@@ -61,8 +64,6 @@ class PasswordController extends Controller {
 		} else {
 			throw new GeneralException("There is no user with that e-mail address.");
 		}
-
-		$this->validate($request, ['email' => 'required|email']);
 
 		$response = Password::sendResetLink($request->only('email'), function (Message $message) {
 			$message->subject($this->getEmailSubject());

--- a/app/Models/Access/User/User.php
+++ b/app/Models/Access/User/User.php
@@ -57,4 +57,12 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 	public function canChangeEmail() {
 		return config('access.users.change_email');
 	}
+
+	/**
+	 * @return bool
+     */
+	public function isBanned()
+	{
+		return $this->status == 2;
+	}
 }

--- a/app/Models/Access/User/User.php
+++ b/app/Models/Access/User/User.php
@@ -61,8 +61,10 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 	/**
 	 * @return bool
      */
-	public function isBanned()
+	public function isBannedOrDeactivated()
 	{
-		return $this->status == 2;
+		$blockedStatuses = [ 0, 2 ];
+
+		return in_array($this->status, $blockedStatuses);
 	}
 }

--- a/app/Repositories/Frontend/Auth/EloquentAuthenticationRepository.php
+++ b/app/Repositories/Frontend/Auth/EloquentAuthenticationRepository.php
@@ -106,9 +106,9 @@ class EloquentAuthenticationRepository implements AuthenticationContract {
 		if (! $request) return $this->getAuthorizationFirst($provider);
 		$user = $this->users->findByUserNameOrCreate($this->getSocialUser($provider), $provider);
 
-		if( $user->isBanned() )
+		if( $user->isBannedOrDeactivated() )
 		{
-			throw new GeneralException("Your account has been banned by an Admin.");
+			throw new GeneralException("Your account has been banned or deactivated by an Admin.");
 		}
 
 		$this->auth->login($user, true);

--- a/app/Repositories/Frontend/Auth/EloquentAuthenticationRepository.php
+++ b/app/Repositories/Frontend/Auth/EloquentAuthenticationRepository.php
@@ -100,10 +100,17 @@ class EloquentAuthenticationRepository implements AuthenticationContract {
 	 * @param $request
 	 * @param $provider
 	 * @return bool|\Symfony\Component\HttpFoundation\RedirectResponse
+	 * @throws GeneralException
 	 */
 	public function loginThirdParty($request, $provider) {
 		if (! $request) return $this->getAuthorizationFirst($provider);
 		$user = $this->users->findByUserNameOrCreate($this->getSocialUser($provider), $provider);
+
+		if( $user->isBanned() )
+		{
+			throw new GeneralException("Your account has been banned by an Admin.");
+		}
+
 		$this->auth->login($user, true);
 		event(new UserLoggedIn($user));
 		return redirect()->route('frontend.dashboard');


### PR DESCRIPTION
If user has been banned or deactivated by an Admin he can't log in with the social account.
This should fix: https://github.com/rappasoft/laravel-5-boilerplate/issues/141

I have also added a small fix in  postEmail method.  
In this way we can check if the email input is filled and the value is a valid email, everything before execute any query.