### PR TITLE
alpha_num unnecessary

### DIFF
--- a/app/Http/Requests/Frontend/Access/ChangePasswordRequest.php
+++ b/app/Http/Requests/Frontend/Access/ChangePasswordRequest.php
@@ -27,7 +27,7 @@ class ChangePasswordRequest extends Request {
 	{
 		return [
 			'old_password'	=>  'required',
-			'password'		=>	'required|alpha_num|min:6|confirmed',
+			'password'		=>	'required|min:6|confirmed',
 		];
 	}
 }


### PR DESCRIPTION
When you register, it doesn't check for "alpha_num" but when you change the password, it checks for it. I suggest to take it out.