### PR TITLE
Rectified belongsToMany() in users function in RoleRelationship & PermissionRelationship

### DIFF
--- a/app/Models/Access/Permission/Traits/Relationship/PermissionRelationship.php
+++ b/app/Models/Access/Permission/Traits/Relationship/PermissionRelationship.php
@@ -32,7 +32,7 @@ trait PermissionRelationship
      */
     public function users()
     {
-        return $this->belongsToMany(config('auth.model'), config('access.permission_user_table'), 'permission_id', 'user_id');
+        return $this->belongsToMany(config('auth.providers.users.model'), config('access.permission_user_table'), 'permission_id', 'user_id');
     }
 
     /**

--- a/app/Models/Access/Role/Traits/Relationship/RoleRelationship.php
+++ b/app/Models/Access/Role/Traits/Relationship/RoleRelationship.php
@@ -13,7 +13,7 @@ trait RoleRelationship
      */
     public function users()
     {
-        return $this->belongsToMany(config('auth.model'), config('access.assigned_roles_table'), 'role_id', 'user_id');
+        return $this->belongsToMany(config('auth.providers.users.model'), config('access.assigned_roles_table'), 'role_id', 'user_id');
     }
 
     /**


### PR DESCRIPTION
use to show below error:
---
FatalErrorException in Model.php line 1011:
Class name must be a valid object or a string
---
on 
admin/access/roles and admin/access/roles/permissions