### PR TITLE
removed the BusServiceProvider.php include on config/compile.php

### DIFF
--- a/config/compile.php
+++ b/config/compile.php
@@ -16,7 +16,6 @@ return [
 	'files' => [
 
 		realpath(__DIR__.'/../app/Providers/AppServiceProvider.php'),
-		realpath(__DIR__.'/../app/Providers/BusServiceProvider.php'),
 		realpath(__DIR__.'/../app/Providers/ConfigServiceProvider.php'),
 		realpath(__DIR__.'/../app/Providers/EventServiceProvider.php'),
 		realpath(__DIR__.'/../app/Providers/RouteServiceProvider.php'),


### PR DESCRIPTION
This PR solves the issue #193 

The `BusServiceProvider.php` was removed on 5.2 version.

Thanks