### PR TITLE
locale - add "All *" for the permission/group tabs

### DIFF
--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -64,9 +64,9 @@ return [
 
                 'tabs' => [
                     'general' => 'General',
-                    'groups' => 'Groups',
+                    'groups' => 'All Groups',
                     'dependencies' => 'Dependencies',
-                    'permissions' => 'Permissions',
+                    'permissions' => 'All Permissions',
                 ],
 
                 'ungrouped_permissions' => 'Ungrouped Permissions',


### PR DESCRIPTION
Since it says *All Groups/Permissions* in the dropdown I would like to add it to the tab description as well.