### PR TITLE
locale pluralization for number of rows in access tables

### DIFF
--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -58,7 +58,7 @@ return [
                     'permission' => 'Permission',
                     'roles' => 'Roles',
                     'system' => 'System',
-                    'total' => 'permissions(s) total',
+                    'total' => 'permission total|permissions total',
                     'users' => 'Users',
                 ],
 
@@ -82,7 +82,7 @@ return [
                     'permissions' => 'Permissions',
                     'role' => 'Role',
                     'sort' => 'Sort',
-                    'total' => 'roles(s) total',
+                    'total' => 'role total|roles total',
                 ],
             ],
 
@@ -114,7 +114,7 @@ return [
                     'no_deleted' => 'No Deleted Users',
                     'other_permissions' => 'Other Permissions',
                     'roles' => 'Roles',
-                    'total' => 'user(s) total',
+                    'total' => 'user total|users total',
                 ],
             ],
         ],

--- a/resources/lang/fr-FR/labels.php
+++ b/resources/lang/fr-FR/labels.php
@@ -58,7 +58,7 @@ return [
                     'permission' => 'Permission',
                     'roles' => 'Rôles',
                     'system' => 'Système',
-                    'total' => 'permissions(s) total',
+                    'total' => 'permission total|permissions total',
                     'users' => 'Utilisateurs',
                 ],
 
@@ -82,7 +82,7 @@ return [
                     'permissions' => 'Permissions',
                     'role' => 'Rôle',
                     'sort' => 'Ordre',
-                    'total' => 'rôles(s) total',
+                    'total' => 'rôle total|rôles total',
                 ],
             ],
 
@@ -114,7 +114,7 @@ return [
                     'no_deleted' => "Pas d'utilisateurs supprimés",
                     'other_permissions' => 'Autres permissions',
                     'roles' => 'Rôles',
-                    'total' => 'utilisateur(s) total',
+                    'total' => 'utilisateur total|utilisateurs total',
                 ],
             ],
         ],

--- a/resources/lang/sv/labels.php
+++ b/resources/lang/sv/labels.php
@@ -58,7 +58,7 @@ return [
                     'permission' => 'Tillstånd',
                     'roles' => 'Roller',
                     'system' => 'System-status',
-                    'total' => 'tillstånd totalt',
+                    'total' => 'tillstånd totalt|tillstånd totalt',
                     'users' => 'Användare',
                 ],
 
@@ -82,7 +82,7 @@ return [
                     'permissions' => 'Tillstånd',
                     'role' => 'Roll',
                     'sort' => 'Ordning',
-                    'total' => 'roll(er) totalt',
+                    'total' => 'roll totalt|roller totalt',
                 ],
             ],
 
@@ -114,7 +114,7 @@ return [
                     'no_deleted' => 'Inga raderade användare',
                     'other_permissions' => 'Övriga tillstånd',
                     'roles' => 'Roller',
-                    'total' => 'användare totalt',
+                    'total' => 'användare totalt|användare totalt',
                 ],
             ],
         ],

--- a/resources/views/backend/access/deactivated.blade.php
+++ b/resources/views/backend/access/deactivated.blade.php
@@ -74,7 +74,7 @@
             </div>
 
             <div class="pull-left">
-                {!! $users->total() !!} {{ trans('labels.backend.access.users.table.total') }}
+                {!! $users->total() !!} {{ trans_choice('labels.backend.access.users.table.total', $users->total()) }}
             </div>
 
             <div class="pull-right">

--- a/resources/views/backend/access/deleted.blade.php
+++ b/resources/views/backend/access/deleted.blade.php
@@ -82,7 +82,7 @@
             </div>
 
             <div class="pull-left">
-                {!! $users->total() !!} {{ trans('labels.backend.access.users.table.total') }}
+                {!! $users->total() !!} {{ trans_choice('labels.backend.access.users.table.total', $users->total()) }}
             </div>
 
             <div class="pull-right">

--- a/resources/views/backend/access/index.blade.php
+++ b/resources/views/backend/access/index.blade.php
@@ -70,7 +70,7 @@
             </div>
 
             <div class="pull-left">
-                {!! $users->total() !!} {{ trans('labels.backend.access.users.table.total') }}
+                {!! $users->total() !!} {{ trans_choice('labels.backend.access.users.table.total', $users->total()) }}
             </div>
 
             <div class="pull-right">

--- a/resources/views/backend/access/roles/index.blade.php
+++ b/resources/views/backend/access/roles/index.blade.php
@@ -57,7 +57,7 @@
             </div>
 
             <div class="pull-left">
-                {{ $roles->total() }} {{ trans('labels.backend.access.roles.table.total') }}
+                {{ $roles->total() }} {{ trans_choice('labels.backend.access.roles.table.total', $roles->total()) }}
             </div>
 
             <div class="pull-right">

--- a/resources/views/backend/access/roles/permissions/index.blade.php
+++ b/resources/views/backend/access/roles/permissions/index.blade.php
@@ -195,7 +195,7 @@
                         </div>
 
                         <div class="pull-left">
-                            {{ $permissions->total() }} {{ trans('labels.backend.access.permissions.table.total') }}
+                            {{ $permissions->total() }} {{ trans_choice('labels.backend.access.permissions.table.total', $permissions->total()) }}
                         </div>
 
                         <div class="pull-right">


### PR DESCRIPTION
Pluralizations for the access tables. 
**Note** 2 of the Swedish translations have the same word independent of singular or plural. Just wanna inform that it is not a duplication.

### Warning for fr-FR though
This PR will not break anything. But, one possibly major thing is that the pluralization trans_choice() does not seem to work at all for the fr-FR version. Soo strange! So as of now, the singular sting is shown all the time for French and only French. I checked the Swedish words that doesn't change normally and that worked. And the English version works just as expected. So its something really fishy about the fr-FR translation here.. I dont understand!
