### PR TITLE
fix for carbon and php localization regarding dates

### DIFF
--- a/app/Http/Middleware/LocaleMiddleware.php
+++ b/app/Http/Middleware/LocaleMiddleware.php
@@ -15,9 +15,9 @@ class LocaleMiddleware
      * @var array
      */
     protected $languages = [
-        'en' => ['en', 'en_US'],
+        'en'    => ['en', 'en_US'],
         'fr-FR' => ['fr', 'fr_FR'],
-        'sv' => ['sv', 'sv_SE'],
+        'sv'    => ['sv', 'sv_SE'],
     ];
 
     /**

--- a/app/Http/Middleware/LocaleMiddleware.php
+++ b/app/Http/Middleware/LocaleMiddleware.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Carbon\Carbon;
 
 /**
  * Class LocaleMiddleware
@@ -13,7 +14,11 @@ class LocaleMiddleware
     /**
      * @var array
      */
-    protected $languages = ['en', 'fr-FR', 'sv'];
+    protected $languages = [
+        'en' => ['en', 'en_US'],
+        'fr-FR' => ['fr', 'fr_FR'],
+        'sv' => ['sv', 'sv_SE'],
+    ];
 
     /**
      * Handle an incoming request.
@@ -22,12 +27,16 @@ class LocaleMiddleware
      * @param  \Closure                 $next
      * @return mixed
      */
-    public function handle($request, Closure $next)
-    {
-        if (session()->has('locale') && in_array(session()->get('locale'), $this->languages)) {
-            app()->setLocale(session()->get('locale'));
-        }
+    public function handle($request, Closure $next){
+        if (session()->has('locale') && array_key_exists(session()->get('locale'), $this->languages)) {
+                app()->setLocale(session()->get('locale'));
 
+                // setLocale for php. Enables ->formatLocalized() with localized values for dates
+                setLocale(LC_TIME, $this->languages[ session()->get('locale') ][1] );
+
+                // setLocale to use Carbon source locales. Enables diffForHumans() localized
+                Carbon::setLocale( $this->languages[ session()->get('locale') ][0] );
+            }
         return $next($request);
     }
 }


### PR DESCRIPTION
This solves #211
Enables localized `diffForHumans()` and `Carbon::now()->formatLocalized()`

# Report on locales
I feel that there is a lot to talk about when it comes to this. Therefore I have tried to gather some info on the subject and try to explain why this is important and how it works.
I have also done some research on language standards for you to take a stand on for the future.

## Why do we need this?
#### What does setLocale() and Carbon::setLocale() do?
**I took french as the example:**
1. Carbon diffForHumans() - **il y a 10 heures** (10 hours ago)
2. Carbon::now()->formatLocalized('%e %B') - **8 janvier** (8 January)

**Solution**
1. `Carbon::setLocale('fr');`
2. `setLocale(LC_TIME, 'fr_FR');` (see [Carbon Docs](http://carbon.nesbot.com/docs/#api-localization))

## Language codes
### 1. Carbon
Carbon uses the ISO-639 standard (**ISO-639-1** to be exact).
[List of ISO-639 locale codes](http://www.loc.gov/standards/iso639-2/php/code_list.php)

**Examples**
* `en` - English
* `fr` - French
* `sv` - Swedish

### 2. PHP
PHP uses the GNU C Library formatting for locale codes. It combines languages and regions to enable more specific libraries. It also uses the **ISO-639-1** for both the *language* and the *region* codes. Language is separated with `_` from region and the region is spelled with capitals.
[List of GNU locale codes](http://lh.2xlibre.net/locales/)

**Examples** *language_REGION*
* `en_US` - English - United States
* `fr_FR` - French - France
* `fr_CH` - French - Switzerland
* `sv_SE` - Swedish - Sweden

--------------------------------------------------------------------------------
# Consideration
1. What standard should this boilerplate follow regarding naming of folders and key name in the `$languages` array?

## Possibilites
### 1. Diversity
To enable more specific translations the combined *language* + *REGION* system is great.
However, now that we have to follow PHP GNU C Library formatting in one case, I think we should use that standard also in the folder names when necessary. *When necessary* I mean with languages that possibly could have multiple regions that wants an translation for example Portuguese, Spanish and French.

##### Pros And Cons
**Pros**
1. Great possibilities to grow and have very specific languages
**Cons**
1. Honestly, possibly a whole lot of poorly updated language packages
2. one pretty ugly array..
```
protected $languages = [
    'en' => ['en', 'en_US'],
    'es_ES' => ['es', 'es_ES'], (spanish - Spain)
    'es_AR' => ['es', 'es_AR'], (spanish - Argentina)
    'fr_FR' => ['fr', 'fr_FR'],
    'pt_BR' => ['pt', 'pt_BR'], (Portuguese - Brazil)
    'pt_PT' => ['pt', 'pt_PT'], (Portuguese - Portugal)
    'sv' => ['sv', 'sv_SE'],
];
```

### 2. Lets be real
Say screw it and only allow one translation per language. Because sure, this repo is getting bigger but it doesn't need to be that language specific? Let's not get things overly complicated?

##### Pros And Cons
**Pros**
1. More simple and slick folder structures
2. More likely to be updated better while less languages
3. A darn fine and easy to manage `$languages` array
**Cons**
1. lost posibility of specific languages
2. Small refactor needs to be done:
* Rename all occurrences of `fr-FR``
. 
* Refactor the `LocaleMiddleware` a litle
```
protected $languages = [
    'en' => 'en_US',
    'es' => es_ES',
    'fr' => 'fr_FR',
    'pt' => 'pt_PT',
    'sv' => 'sv_SE',
];
```
--------------------------------------------------------------------------------

What do you say?
I would say option 2 and then good night to you good sir.