### PR TITLE
Revert "defaulttimestamp"

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,7 +21,7 @@ class CreateUsersTable extends Migration
             $table->boolean('confirmed')->default(config('access.users.confirm_email') ? false : true);
             $table->rememberToken();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default('0000-00-00 00:00');
             $table->softDeletes();
         });
     }

--- a/database/migrations/2015_12_28_171741_create_social_logins_table.php
+++ b/database/migrations/2015_12_28_171741_create_social_logins_table.php
@@ -19,7 +19,7 @@ class CreateSocialLoginsTable extends Migration
             $table->string('provider', 32);
             $table->string('provider_id');
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default('0000-00-00 00:00');
         });
     }
 

--- a/database/migrations/2015_12_29_015055_setup_access_tables.php
+++ b/database/migrations/2015_12_29_015055_setup_access_tables.php
@@ -22,7 +22,7 @@ class SetupAccessTables extends Migration
             $table->boolean('all')->default(false);
             $table->smallInteger('sort')->default(0)->unsigned();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default('0000-00-00 00:00');
 
             /**
              * Add Foreign/Unique/Index
@@ -57,7 +57,7 @@ class SetupAccessTables extends Migration
             $table->boolean('system')->default(false);
             $table->smallInteger('sort')->default(0)->unsigned();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default('0000-00-00 00:00');
 
             /**
              * Add Foreign/Unique/Index
@@ -71,7 +71,7 @@ class SetupAccessTables extends Migration
             $table->string('name');
             $table->smallInteger('sort')->default(0);
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default('0000-00-00 00:00');
         });
 
         Schema::create(config('access.permission_role_table'), function ($table) {
@@ -98,7 +98,7 @@ class SetupAccessTables extends Migration
             $table->integer('permission_id')->unsigned();
             $table->integer('dependency_id')->unsigned();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default('0000-00-00 00:00');
 
             /**
              * Add Foreign/Unique/Index


### PR DESCRIPTION
This reverts commit 82cf79650656608f3dc518e4090a27c98341b993.

MySQL before 5.7 does not accept more than one default CURRENT_TIMESTAMP per table. Repositories for popular distributions are still using 5.5 and 5.6.