### PR TITLE
Remove the default value on updated_at columns

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,7 +21,7 @@ class CreateUsersTable extends Migration
             $table->boolean('confirmed')->default(config('access.users.confirm_email') ? false : true);
             $table->rememberToken();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at');
             $table->softDeletes();
         });
     }

--- a/database/migrations/2015_12_28_171741_create_social_logins_table.php
+++ b/database/migrations/2015_12_28_171741_create_social_logins_table.php
@@ -19,7 +19,7 @@ class CreateSocialLoginsTable extends Migration
             $table->string('provider', 32);
             $table->string('provider_id');
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at');
         });
     }
 

--- a/database/migrations/2015_12_29_015055_setup_access_tables.php
+++ b/database/migrations/2015_12_29_015055_setup_access_tables.php
@@ -22,7 +22,7 @@ class SetupAccessTables extends Migration
             $table->boolean('all')->default(false);
             $table->smallInteger('sort')->default(0)->unsigned();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at');
 
             /**
              * Add Foreign/Unique/Index
@@ -57,7 +57,7 @@ class SetupAccessTables extends Migration
             $table->boolean('system')->default(false);
             $table->smallInteger('sort')->default(0)->unsigned();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at');
 
             /**
              * Add Foreign/Unique/Index
@@ -71,7 +71,7 @@ class SetupAccessTables extends Migration
             $table->string('name');
             $table->smallInteger('sort')->default(0);
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at');
         });
 
         Schema::create(config('access.permission_role_table'), function ($table) {
@@ -98,7 +98,7 @@ class SetupAccessTables extends Migration
             $table->integer('permission_id')->unsigned();
             $table->integer('dependency_id')->unsigned();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
-            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at');
 
             /**
              * Add Foreign/Unique/Index


### PR DESCRIPTION
With MySQL 5.5, you should not have a default value of `CURRENT_TIMESTAMP` on more then one column at the same time. Also, a column added with no default

>  it is the same as specifying both `DEFAULT CURRENT_TIMESTAMP` and `ON UPDATE CURRENT_TIMESTAMP`.
>              (https://dev.mysql.com/doc/refman/5.5/en/timestamp-initialization.html)

This PR will remove the default current timestamps, and ensure that no default value is set on them.