### PR TITLE
Feature/social logins

### DIFF
--- a/app/Repositories/Frontend/User/EloquentUserRepository.php
+++ b/app/Repositories/Frontend/User/EloquentUserRepository.php
@@ -147,7 +147,17 @@ class EloquentUserRepository implements UserContract
             $user->providers()->save(new SocialLogin([
                 'provider'    => $provider,
                 'provider_id' => $data->id,
+                'token'       => $data->token,
+                'avatar'      => $data->avatar,
             ]));
+        }else{
+             /**
+             * Update the users information, token and avatar can be updated.
+             */
+            $user->providers()->update([
+                'token'       => $data->token,
+                'avatar'      => $data->avatar,
+            ]);
         }
 
         /**

--- a/app/Repositories/Frontend/User/EloquentUserRepository.php
+++ b/app/Repositories/Frontend/User/EloquentUserRepository.php
@@ -133,7 +133,7 @@ class EloquentUserRepository implements UserContract
         if (! $user) {
             $user = $this->create([
                 'name'  => $data->name,
-                'email' => $data->email,
+                'email' => $data->email ? : "{$data->id}@{$provider}.com",
             ], true);
         }
 

--- a/database/migrations/2015_12_28_171741_create_social_logins_table.php
+++ b/database/migrations/2015_12_28_171741_create_social_logins_table.php
@@ -18,6 +18,8 @@ class CreateSocialLoginsTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->string('provider', 32);
             $table->string('provider_id');
+            $table->string('token')->nullable();
+            $table->string('avatar')->nullable();
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
             $table->timestamp('updated_at');
         });


### PR DESCRIPTION
this PR adds the feature discussed in issue #265 

This PR adds 2 columns to the `social_logins` table 
- adds token (to be used for authenticated calls beyond authentication)
- adds social avatar, to display users avatar from their social connection.

classes changed/updated.

`App\Repositories\Frontend\UserEloquentUserRepository@findOrCreateSocial`

- new `SocialLogin` now accepts `token` and `avatar`
- returning users `SocialLogin` now updates `token` and `avatar`
- `SocialLogin` with `NULL` email address now defaults to `"{$provider_id}@{$provider}.com"`


this has been tested with Twitter, Facebook and Github Auth.

