### PR TITLE
Hide secret token in resend confirmation link

### DIFF
--- a/app/Http/Routes/Frontend/Access.php
+++ b/app/Http/Routes/Frontend/Access.php
@@ -37,7 +37,7 @@ Route::group(['namespace' => 'Auth'], function () {
         // Confirm Account Routes
         Route::get('account/confirm/{token}', 'AuthController@confirmAccount')
             ->name('account.confirm');
-        Route::get('account/confirm/resend/{token}', 'AuthController@resendConfirmationEmail')
+        Route::get('account/confirm/resend/{user_id}', 'AuthController@resendConfirmationEmail')
             ->name('account.confirm.resend');
 
         // Password Reset Routes

--- a/app/Repositories/Frontend/Access/User/EloquentUserRepository.php
+++ b/app/Repositories/Frontend/Access/User/EloquentUserRepository.php
@@ -204,12 +204,12 @@ class EloquentUserRepository implements UserRepositoryContract
     }
 
     /**
-     * @param $token
+     * @param $user_id
      * @return mixed
      * @throws GeneralException
      */
-    public function resendConfirmationEmail($token) {
-        return $this->sendConfirmationEmail($this->findByToken($token));
+    public function resendConfirmationEmail($user_id) {
+        return $this->sendConfirmationEmail($this->find($user_id));
     }
 
     /**

--- a/app/Services/Access/Traits/AuthenticatesUsers.php
+++ b/app/Services/Access/Traits/AuthenticatesUsers.php
@@ -104,9 +104,9 @@ trait AuthenticatesUsers
          * Check to see if the users account is confirmed and active
          */
         if (! access()->user()->isConfirmed()) {
-            $token = access()->user()->confirmation_code;
+            $id = access()->user()->id;
             auth()->logout();
-            throw new GeneralException(trans('exceptions.frontend.auth.confirmation.resend', ['token' => $token]));
+            throw new GeneralException(trans('exceptions.frontend.auth.confirmation.resend', ['user_id' => $id]));
         } elseif (! access()->user()->isActive()) {
             auth()->logout();
             throw new GeneralException(trans('exceptions.frontend.auth.deactivated'));

--- a/resources/lang/da/exceptions.php
+++ b/resources/lang/da/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => 'Din konto blev oprettet. Vi har sendt dig en e-mail for at bekræfte din konto.',
                 'mismatch' => 'Din bekræftelseskode matcher ikke.',
                 'not_found' => 'At bekræftelseskode findes ikke.',
-                'resend' => 'Din konto er ikke bekræftet. Klik på linket bekræftelse e-mail eller <a href="' . route('account.confirm.resend', ':token') . '">tryk her</a> for at gensende bekræftelses e-mailen.',
+                'resend' => 'Din konto er ikke bekræftet. Klik på linket bekræftelse e-mail eller <a href="' . route('account.confirm.resend', ':user_id') . '">tryk her</a> for at gensende bekræftelses e-mailen.',
                 'success' => 'Din konto er blevet succesfuldt bekræftet!',
                 'resent' => 'En ny bekræftelses e-mail er blevet sendt til adressen vi kender.',
             ],

--- a/resources/lang/de/exceptions.php
+++ b/resources/lang/de/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => 'Dein Account wurde erstellt. Wir haben dir eiene Aktivierungsmail gesendet.',
                 'mismatch' => 'Der Aktivierungscode ist nicht korrekt.',
                 'not_found' => 'Der Aktivierungscode existiert nicht.',
-                'resend' => 'Dein Account ist nicht aktiviert. Bitte klicke auf den Link in der Aktivierungsmail, oder <a href="' . route('account.confirm.resend', ':token') . '">klicke hier</a> um die aktivierungsmail erneut zu senden.',
+                'resend' => 'Dein Account ist nicht aktiviert. Bitte klicke auf den Link in der Aktivierungsmail, oder <a href="' . route('account.confirm.resend', ':user_id') . '">klicke hier</a> um die aktivierungsmail erneut zu senden.',
                 'success' => 'Dein Account wurde aktiviert!',
                 'resent' => 'Eine neue aktivierungsmail wurde an die hinterlegte E-Mailadresse gesendet.',
             ],

--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => 'Your account was successfully created. We have sent you an e-mail to confirm your account.',
                 'mismatch' => 'Your confirmation code does not match.',
                 'not_found' => 'That confirmation code does not exist.',
-                'resend' => 'Your account is not confirmed. Please click the confirmation link in your e-mail, or <a href="' . route('account.confirm.resend', ':token') . '">click here</a> to resend the confirmation e-mail.',
+                'resend' => 'Your account is not confirmed. Please click the confirmation link in your e-mail, or <a href="' . route('account.confirm.resend', ':user_id') . '">click here</a> to resend the confirmation e-mail.',
                 'success' => 'Your account has been successfully confirmed!',
                 'resent' => 'A new confirmation e-mail has been sent to the address on file.',
             ],

--- a/resources/lang/es/exceptions.php
+++ b/resources/lang/es/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => 'Su cuenta ha sido creada. Le hemos enviado un e-mail con un enlace de verificación.',
                 'mismatch' => 'El código de verificación no coincide.',
                 'not_found' => 'El código de verificación especificado no existe.',
-                'resend' => 'Su cuenta no ha sido verificada todavía. Por favor, revide su e-mail, o <a href="' . route('account.confirm.resend', ':token') . '">pulse aqui</a> para re-enviar el correo de verificación.',
+                'resend' => 'Su cuenta no ha sido verificada todavía. Por favor, revide su e-mail, o <a href="' . route('account.confirm.resend', ':user_id') . '">pulse aqui</a> para re-enviar el correo de verificación.',
                 'success' => 'Su cuenta ha sido verificada satisfactoriamente!',
                 'resent' => 'Un nuevo correo de verificación le ha sido enviado.',
             ],

--- a/resources/lang/fr/exceptions.php
+++ b/resources/lang/fr/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => 'Votre compte a été créé avec succès.  Un email de confirmation vous a été envoyé.',
                 'mismatch' => 'Votre code de confirmation est invalide.',
                 'not_found' => "Votre code de confirmation n'existe pas.",
-                'resend' => 'Votre compte n\'est pas confirmé. Veuillez utiliser le lien qui vous a été envoyé par email, ou <a href="' . route('account.confirm.resend', ':token') . '">cliquez ici </a> pour recevoir un email de nouveau.',
+                'resend' => 'Votre compte n\'est pas confirmé. Veuillez utiliser le lien qui vous a été envoyé par email, ou <a href="' . route('account.confirm.resend', ':user_id') . '">cliquez ici </a> pour recevoir un email de nouveau.',
                 'success' => "Votre compte est dorénavant confirmé !",
                 'resent' => "Un nouvel email a été envoyé à l'adresse enregistrée.",
             ],

--- a/resources/lang/it/exceptions.php
+++ b/resources/lang/it/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => "Il tuo account è stato creato con successo. Ti abbiamo inviato un'email per confermare il tuo account.",
                 'mismatch' => 'Il tuo codice di conferma non corrisponde',
                 'not_found' => 'Questo codice di conferma non esiste.',
-                'resend' => 'Il tuo account non è confermato. Per cortesia clicca sul link di conferma nell\'email che ti abbiamo mandato, o <a href="' . route('account.confirm.resend', ':token') . '">clicca qui</a> per rimandare l\'email di conferma.',
+                'resend' => 'Il tuo account non è confermato. Per cortesia clicca sul link di conferma nell\'email che ti abbiamo mandato, o <a href="' . route('account.confirm.resend', ':user_id') . '">clicca qui</a> per rimandare l\'email di conferma.',
                 'success' => "Il tuo account è stato confermato con successo!",
                 'resent' => "Una nuova e-mail di conferma è stata inviata all'indirizzo registrato.",
             ],

--- a/resources/lang/pt-BR/exceptions.php
+++ b/resources/lang/pt-BR/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => 'Sua conta foi criada com sucesso. Enviamos um e-mail para você confirmar a sua conta.',
                 'mismatch' => 'Seu código de confirmação não corresponde.',
                 'not_found' => 'Esse código de confirmação não existe.',
-                'resend' => 'Sua conta não está confirmada. Por favor, clique no link de confirmação em seu e-mail, ou <a href="' . route('account.confirm.resend', ':token') . '">clique aqui</a> para reenviar o e-mail de confirmação.',
+                'resend' => 'Sua conta não está confirmada. Por favor, clique no link de confirmação em seu e-mail, ou <a href="' . route('account.confirm.resend', ':user_id') . '">clique aqui</a> para reenviar o e-mail de confirmação.',
                 'success' => 'Sua conta foi confirmada com sucesso!',
                 'resent' => 'Um novo e-mail de confirmação foi enviado para você.',
             ],

--- a/resources/lang/sv/exceptions.php
+++ b/resources/lang/sv/exceptions.php
@@ -66,7 +66,7 @@ return [
                 'created_confirm' => 'Ditt konto är nu skapat. Vi har skickat ett mail till dig där du kan bekräfta och aktivera ditt konto.',
                 'mismatch' => 'Din bekräftelsekod för aktivering stämmer inte.',
                 'not_found' => 'Din bekräftelsekod för aktivering stämmer inte.',
-                'resend' => 'Du måste bekräfta och aktivera ditt konto för att fortsätta. Bekräfta och aktivera ditt konto genom länken i mailet vi skickade till dig. <a href="' . route('account.confirm.resend', ':token') . '">Klicka här</a> för att skicka mailet en gång till.',
+                'resend' => 'Du måste bekräfta och aktivera ditt konto för att fortsätta. Bekräfta och aktivera ditt konto genom länken i mailet vi skickade till dig. <a href="' . route('account.confirm.resend', ':user_id') . '">Klicka här</a> för att skicka mailet en gång till.',
                 'success' => 'Ditt konto har nu bekräftats och aktiverats.',
                 'resent' => 'Ett nytt mail med länk för bekräftelse och aktivering har nu skickats till den angivna e-posten.',
             ],


### PR DESCRIPTION
Fixed security problem  described here https://github.com/rappasoft/laravel-5-boilerplate/issues/336