### PR TITLE
Exclude node_modules from backup

### DIFF
--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -28,6 +28,7 @@ return [
                  */
                 'exclude' => [
                     base_path('vendor'),
+                    base_path('node_modules'),
                     storage_path(),
                 ],
             ],


### PR DESCRIPTION
Excluded the `node_modules` folder from the backup.

Not in this PR, but I'd also opt to not exclude `storage_path()`, since user uploads tend to be stored there sometimes.