### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Laravel 5 Boilerplate project on Nitrous.
+
+## Running the Laravel 5 Boilerplate server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Jekyll Now via "Run > Start Laravel 5 Boilerplate"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 8000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "php-apache",
+  "ports": [8000],
+  "name": "Laravel 5 Boilerplate",
+  "description": "A Laravel 5 Boilerplate Project",
+  "scripts": {
+    "post-create": "sudo apt-get update && sudo apt-get install -y php-mbstring && npm install -g gulp && composer install && npm install && mysql -u root -e 'create database homestead' && cp .env.example .env && sed -i 's|DB_USERNAME=homestead|DB_USERNAME=nitrous|g' .env && sed -i 's|DB_PASSWORD=secret|DB_PASSWORD=|g' .env && php artisan key:generate && php artisan migrate && php artisan db:seed && gulp",
+    "Start Laravel 5 Boilerplate": "cd ~/code/laravel-5-boilerplate && php artisan serve --host 0.0.0.0"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages

Quickstart button should be added to wiki section of this repo (i.e. https://github.com/rappasoft/laravel-5-boilerplate/wiki/1.-Installation). Here's the markdown for Quickstart button.

```
### Nitrous Quickstart
Create a free development environment for this Laravel 5 Boilerplate project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
<a href="https://www.nitrous.io/quickstart?repo=https://github.com/rappasoft/laravel-5-boilerplate">
  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
</a>
In the IDE, start Laravel 5 Boilerplate via `Run > Start Laravel 5 Boilerplate` and access your site via `Preview > 8000`.
```