### PR TITLE
Remove duplicate MAIL_DRIVER from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,6 @@ DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 
-MAIL_DRIVER=mail
 CACHE_DRIVER=file
 SESSION_DRIVER=file
 QUEUE_DRIVER=sync


### PR DESCRIPTION
This made me waste a few minutes as I didn't notice it.

MAIL_* env should be next to each other, after all.