### PR TITLE
Configure adminlte layout via config file

### DIFF
--- a/config/backend.php
+++ b/config/backend.php
@@ -49,5 +49,5 @@ return [
      *
      * Note: you cannot use both layout-boxed and fixed at the same time. Anything else can be mixed together.
      */
-    'layout' => 'layout-top-nav sidebar-mini',
+    'layout' => '',
 ];

--- a/config/backend.php
+++ b/config/backend.php
@@ -21,4 +21,33 @@ return [
      * yellow-light
      */
     'theme' => 'blue',
+
+    /**
+     * Layout for the Admin LTE backend theme
+     *
+     * Fixed:               use the class .fixed to get a fixed header and sidebar.
+     *                      This makes scrolling affect the content only and put the sidebar and header in a fixed position.
+     *
+     * Collapsed Sidebar:   use the class .sidebar-collapse to have a collapsed sidebar upon loading.
+     *                      Use this if you want the sidebar to be hidden by default.
+     *
+     * Boxed Layout:        use the class .layout-boxed to get a boxed layout that stretches only to 1250px.
+     *                      Provides spaces on both sides of the screen, if the screen is big enough.
+     *
+     * Top Navigation:      use the class .layout-top-nav to remove the sidebar and have your links at the top navbar.
+     *                      Makes the sidebar hover the content when expanded.
+     *
+     * Sidebar Mini:        Shows the only the icons of the sidebar items when collapsed. Sidebar will not fully collapse.
+     *
+     * Available options:
+     *
+     * fixed
+     * sidebar-collapse
+     * layout-boxed
+     * layout-top-nav
+     * sidebar-mini
+     *
+     * Note: you cannot use both layout-boxed and fixed at the same time. Anything else can be mixed together.
+     */
+    'layout' => 'layout-top-nav sidebar-mini',
 ];

--- a/resources/views/backend/layouts/master.blade.php
+++ b/resources/views/backend/layouts/master.blade.php
@@ -34,7 +34,7 @@
         {{ HTML::script('https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js') }}
         <![endif]-->
     </head>
-    <body class="skin-{{ config('backend.theme') }}">
+    <body class="skin-{{ config('backend.theme') }} {{ config('backend.layout') }}">
         @include('includes.partials.logged-in-as')
 
         <div class="wrapper">


### PR DESCRIPTION
I had to change it on my own. Probably useful if it is in config.

I copied the layout first line descriptions from the main Admin LTE theme documentation, then added my interpretation of it on the second line.

Sidebar mini was not in the documentation but it I do use it and i think it is missing from their docs.