### PR TITLE
History limit

### DIFF
--- a/app/Repositories/Backend/History/EloquentHistoryRepository.php
+++ b/app/Repositories/Backend/History/EloquentHistoryRepository.php
@@ -39,10 +39,11 @@ class EloquentHistoryRepository implements HistoryContract {
 	}
 
 	/**
+	 * @param int $limit
 	 * @return string
 	 */
-	public function render() {
-		$history = History::with('user')->latest()->get();
+	public function render($limit = null) {
+		$history = History::with('user')->take($limit)->latest()->get();
 
 		if (! $history->count())
 			return trans("history.backend.none");
@@ -52,17 +53,18 @@ class EloquentHistoryRepository implements HistoryContract {
 
 	/**
 	 * @param $type
+	 * @param int $limit
 	 * @return string
 	 */
-	public function renderType($type) {
+	public function renderType($type, $limit = null) {
 		if (is_numeric($type)) {
-			$history = History::with('user')->where('type_id', $type)->latest()->get();
+			$history = History::with('user')->where('type_id', $type)->take($limit)->latest()->get();
 		} else {
 			$type = strtolower($type);
 
 			$history = History::whereHas('type', function ($query) use ($type) {
 				$query->where('name', ucfirst($type));
-			})->latest()->get();
+			})->take($limit)->latest()->get();
 		}
 
 		if (! $history->count())
@@ -73,10 +75,11 @@ class EloquentHistoryRepository implements HistoryContract {
 
 	/**
 	 * @param $entity_id
+	 * @param int $limit
 	 * @return string
 	 */
-	public function renderEntity($entity_id) {
-		$history = History::with('user', 'type')->where('entity_id', $entity_id)->latest()->get();
+	public function renderEntity($entity_id, $limit = null) {
+		$history = History::with('user', 'type')->where('entity_id', $entity_id)->take($limit)->latest()->get();
 
 		if (! $history->count())
 			return trans("history.backend.none_for_entity", ['entity' => $history->type->name]);

--- a/app/Repositories/Backend/History/HistoryContract.php
+++ b/app/Repositories/Backend/History/HistoryContract.php
@@ -21,23 +21,29 @@ interface HistoryContract {
 
 	/**
 	 * @param int $limit
+	 * @param bool $paginate
+	 * @param int $pagination
 	 * @return mixed
 	 */
-	public function render($limit = null);
+	public function render($limit = null, $paginate = false, $pagination = 10);
 
 	/**
 	 * @param $type
 	 * @param int $limit
+	 * @param bool $paginate
+	 * @param int $pagination
 	 * @return mixed
 	 */
-	public function renderType($type, $limit = null);
+	public function renderType($type, $limit = null, $paginate = false, $pagination = 10);
 
 	/**
 	 * @param $entity_id
 	 * @param int $limit
+	 * @param bool $paginate
+	 * @param int $pagination
 	 * @return mixed
 	 */
-	public function renderEntity($entity_id, $limit = null);
+	public function renderEntity($entity_id, $limit = null, $paginate = false, $pagination = 10);
 
 	/**
 	 * @param $text
@@ -50,11 +56,11 @@ interface HistoryContract {
 	 * @param $items
 	 * @return mixed
 	 */
-	public function buildList($items);
+	public function buildList($history);
 
 	/**
 	 * @param History $history
 	 * @return mixed
 	 */
-	public function buildItem(History $history);
+	public function buildItem(History $historyItem);
 }

--- a/app/Repositories/Backend/History/HistoryContract.php
+++ b/app/Repositories/Backend/History/HistoryContract.php
@@ -20,21 +20,24 @@ interface HistoryContract {
 	public function log($type, $text, $entity_id = null, $icon = null, $class = null,  $assets = null);
 
 	/**
+	 * @param int $limit
 	 * @return mixed
 	 */
-	public function render();
+	public function render($limit = null);
 
 	/**
 	 * @param $type
+	 * @param int $limit
 	 * @return mixed
 	 */
-	public function renderType($type);
+	public function renderType($type, $limit = null);
 
 	/**
 	 * @param $entity_id
+	 * @param int $limit
 	 * @return mixed
 	 */
-	public function renderEntity($entity_id);
+	public function renderEntity($entity_id, $limit = null);
 
 	/**
 	 * @param $text

--- a/resources/views/includes/partials/history-item.blade.php
+++ b/resources/views/includes/partials/history-item.blade.php
@@ -1,0 +1,7 @@
+<li>
+	<i class="fa fa-{{ $historyItem->icon }} {{ $historyItem->class }}"></i>
+	<div class="timeline-item">
+		<span class="time"><i class="fa fa-clock-o"></i> {{ $historyItem->created_at->diffForHumans() }}</span>
+		<h3 class="timeline-header no-border"><strong>{{ $historyItem->user->name }}</strong> {!! history()->renderDescription($historyItem->text, $historyItem->assets) !!}</h3>
+	</div>
+</li>

--- a/resources/views/includes/partials/history.blade.php
+++ b/resources/views/includes/partials/history.blade.php
@@ -1,0 +1,8 @@
+<ul class="timeline">
+	@foreach ($history as $historyItem)
+		{!! history()->buildItem($historyItem) !!}
+	@endforeach
+</ul>
+@if($paginate)
+	{{ $history->links() }}
+@endif


### PR DESCRIPTION
Add a limit to the amount of "History" taken from the database. In my application, there could be 1000 events that happen over the course of an entities lifetime, and in certain views only seeing the last 10 or so is better than 1000.