### PR TITLE
added transaltion for delete role alert

### DIFF
--- a/app/Models/Access/Role/Traits/Attribute/RoleAttribute.php
+++ b/app/Models/Access/Role/Traits/Attribute/RoleAttribute.php
@@ -23,7 +23,12 @@ trait RoleAttribute
     {
         //Can't delete master admin role
         if ($this->id != 1) {
-            return '<a href="' . route('admin.access.role.destroy', $this) . '" class="btn btn-xs btn-danger" data-method="delete"><i class="fa fa-times" data-toggle="tooltip" data-placement="top" title="' . trans('buttons.general.crud.delete') . '"></i></a>';
+            return '<a href="' . route('admin.access.role.destroy', $this) . '"
+                data-method="delete"
+                data-trans-button-cancel="' . trans('buttons.general.cancel') . '"
+                data-trans-button-confirm="' . trans('buttons.general.crud.delete') . '"
+                data-trans-title="' . trans('strings.backend.general.are_you_sure') . '"
+                class="btn btn-xs btn-danger"><i class="fa fa-times" data-toggle="tooltip" data-placement="top" title="' . trans('buttons.general.crud.delete') . '"></i></a>';
         }
 
         return '';


### PR DESCRIPTION
The alert to confirm deleting roles did not support translation, I just appended to it the following attributes.

+                data-trans-button-cancel="' . trans('buttons.general.cancel') . '"
+                data-trans-button-confirm="' . trans('buttons.general.crud.delete') . '"
+                data-trans-title="' . trans('strings.backend.general.are_you_sure') . '"