### PR TITLE
Fix confirmation email bug when "Send Confirmation E-mail" checkbox used on manual creation of user

### DIFF
--- a/app/Repositories/Backend/Access/User/EloquentUserRepository.php
+++ b/app/Repositories/Backend/Access/User/EloquentUserRepository.php
@@ -76,7 +76,7 @@ class EloquentUserRepository implements UserRepositoryContract
     {
         $user = $this->createUserStub($input);
 
-		DB::transaction(function() use ($user, $roles) {
+		DB::transaction(function() use ($user, $roles, $input) {
 			if ($user->save()) {
 				//User Created, Validate Roles
 				$this->validateRoleAmount($user, $roles['assignees_roles']);


### PR DESCRIPTION
Emails were not sent if the you had "Send Confirmation E-mail" selected on user creation as `$input` wasn't in scope.