### PR TITLE
fix for broken link for log-viewer when filter for All

### DIFF
--- a/routes/Backend/LogViewer.php
+++ b/routes/Backend/LogViewer.php
@@ -33,6 +33,9 @@ Route::group([
 			'as'   => 'log-viewer::logs.show',
 			'uses' => '\Arcanedev\LogViewer\Http\Controllers\LogViewerController@show',
 		]);
+		Route::get('/all', function ($date){
+			return redirect()->route('admin.log-viewer::logs.show', [$date]);
+		});
 		Route::get('download', [
 			'as'   => 'log-viewer::logs.download',
 			'uses' => '\Arcanedev\LogViewer\Http\Controllers\LogViewerController@download',


### PR DESCRIPTION
So when inside `/admin/log-viewer/2016-10-19` you can click in the menu to  select filters. But when selecting **All** there is an error:
````
InvalidArgumentException in UrlGenerator.php line 314:
Route [log-viewer::logs.show] not defined.
````

This code fixes the issue but I guess it's not the right way to go.
I checked to see if this was an error with LogViewer but that is not the case.

I tried a fresh install of laravel and added the LogViewer and that worked just fine. Have been trying to find the reason to why the _All_ route does not work in this project but I could not find anything... At least this fixes it, its not perfect and not the best solution but it gets fixed.

Have a look at it if you think you'll be able to spot the mistake somewhere.
