### PR TITLE
Fixed Carbon configuration at AppServiceProvider.php to use 'app.loca…

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,7 +32,7 @@ class AppServiceProvider extends ServiceProvider
 		/**
 		 * setLocale to use Carbon source locales. Enables diffForHumans() localized
 		 */
-		Carbon::setLocale(config('app.locale'));
+		Carbon::setLocale(config('app.locale_php'));
 
 		/**
 		 * Set the session variable for whether or not the app is using RTL support


### PR DESCRIPTION
I've forked the project and tried to configure it to use **pt-BR language**. To do so, I've set the `.env` file as follows:

```
APP_LOCALE=pt-BR
APP_FALLBACK_LOCALE=en
APP_LOCALE_PHP=pt_BR
```

But when I run it, I get an exception on Carbon configuration, at `AppServiceProvider.php`. Carbon utilize `'pt_BR'` format in its language directories, not `'pt-BR'`. So I've altered the `AppServiceProvider.php` to use `'app.locale_php'` instead of `'app.locale'`.