### PR TITLE
Fix placeholder on user creation

### DIFF
--- a/resources/views/backend/access/create.blade.php
+++ b/resources/views/backend/access/create.blade.php
@@ -47,10 +47,10 @@
                 </div><!--form control-->
 
                 <div class="form-group">
-                    {{ Form::label('password_confirmation', trans('validation.attributes.backend.access.users.password_confirmation'), ['class' => 'col-lg-2 control-label', 'placeholder' => trans('validation.attributes.backend.access.users.password_confirmation')]) }}
+                    {{ Form::label('password_confirmation', trans('validation.attributes.backend.access.users.password_confirmation'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::password('password_confirmation', ['class' => 'form-control']) }}
+                        {{ Form::password('password_confirmation', ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.password_confirmation']) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 

--- a/resources/views/backend/access/create.blade.php
+++ b/resources/views/backend/access/create.blade.php
@@ -39,10 +39,10 @@
                 </div><!--form control-->
 
                 <div class="form-group">
-                    {{ Form::label('password', trans('validation.attributes.backend.access.users.password'), ['class' => 'col-lg-2 control-label', 'placeholder' => trans('validation.attributes.backend.access.users.password')]) }}
+                    {{ Form::label('password', trans('validation.attributes.backend.access.users.password'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::password('password', ['class' => 'form-control']) }}
+                        {{ Form::password('password', ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.password')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 


### PR DESCRIPTION
Incredibly minor fix. The placeholder is set to the label instead of the input on the creation form in the admin backend
