### PR TITLE
Rename driver name to 'pgsql' for Postgres

### DIFF
--- a/database/DisableForeignKeys.php
+++ b/database/DisableForeignKeys.php
@@ -25,7 +25,7 @@ trait DisableForeignKeys
             'enable' => 'EXEC sp_msforeachtable @command1="print \'?\'", @command2="ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all";',
             'disable' => 'EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all";',
         ],
-        'postgres' => [
+        'pgsql' => [
             'enable' => 'SET CONSTRAINTS ALL IMMEDIATE;',
             'disable' => 'SET CONSTRAINTS ALL DEFERRED;',
         ],


### PR DESCRIPTION
The key for db should be 'pgsql' instead of 'postgres' to avoid the "unknown index: pgsql" Error when using Postgres as your database and execute seed command.

