### PR TITLE
Disable social logon creating accounts when registration is disabled

### DIFF
--- a/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
@@ -64,7 +64,18 @@ class SocialLoginController extends Controller
         /**
          * Create the user if this is a new social account or find the one that is already there.
          */
-        $user = $this->user->findOrCreateSocial($this->getSocialUser($provider), $provider);
+        $user = null ;
+        try {
+            $user = $this->user->findOrCreateSocial($this->getSocialUser($provider), $provider);
+        } catch (GeneralException $e) {
+            return redirect()->route('frontend.index')->withFlashDanger($e->getMessage());
+        }
+
+        if (!isset($user)) {
+            return redirect()->route('frontend.index')->withFlashDanger(trans('exceptions.frontend.auth.unknown'));
+        } else if (! $user->isActive()) {
+            return redirect()->route('frontend.index')->withFlashDanger(trans('exceptions.frontend.auth.deactivated'));
+        }
 
         /*
          * User has been successfully created or already exists

--- a/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
@@ -64,16 +64,16 @@ class SocialLoginController extends Controller
         /**
          * Create the user if this is a new social account or find the one that is already there.
          */
-        $user = null ;
+        $user = null;
         try {
             $user = $this->user->findOrCreateSocial($this->getSocialUser($provider), $provider);
         } catch (GeneralException $e) {
             return redirect()->route('frontend.index')->withFlashDanger($e->getMessage());
         }
 
-        if (!isset($user)) {
+        if (! isset($user)) {
             return redirect()->route('frontend.index')->withFlashDanger(trans('exceptions.frontend.auth.unknown'));
-        } else if (! $user->isActive()) {
+        } elseif (! $user->isActive()) {
             return redirect()->route('frontend.index')->withFlashDanger(trans('exceptions.frontend.auth.deactivated'));
         }
 

--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -144,7 +144,7 @@ class UserRepository extends BaseRepository
          * Which triggers the script to use some default values in the create method
          */
         if (! $user) {
-            if (!config('access.users.enable_registration')) {
+            if (! config('access.users.enable_registration')) {
                 throw new GeneralException(trans('exceptions.frontend.auth.registration_not_enabled'));
             }
             $user = $this->create([

--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -124,6 +124,7 @@ class UserRepository extends BaseRepository
      * @param $provider
      *
      * @return UserRepository|bool
+     * @throws GeneralException
      */
     public function findOrCreateSocial($data, $provider)
     {
@@ -143,6 +144,9 @@ class UserRepository extends BaseRepository
          * Which triggers the script to use some default values in the create method
          */
         if (! $user) {
+            if (!config('access.users.enable_registration')) {
+                throw new GeneralException(trans('exceptions.frontend.auth.registration_not_enabled'));
+            }
             $user = $this->create([
                 'name'  => $data->name,
                 'email' => $user_email,

--- a/config/database.php
+++ b/config/database.php
@@ -68,7 +68,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset' => 'utf8',
             'prefix' => '',
-            'schema' => 'public',
+            'schema' => [env('DB_SCHEMA', 'public'), 'public'],
             'sslmode' => 'prefer',
         ],
 

--- a/database/DisableForeignKeys.php
+++ b/database/DisableForeignKeys.php
@@ -25,7 +25,7 @@ trait DisableForeignKeys
             'enable' => 'EXEC sp_msforeachtable @command1="print \'?\'", @command2="ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all";',
             'disable' => 'EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all";',
         ],
-        'postgres' => [
+        'pgsql' => [
             'enable' => 'SET CONSTRAINTS ALL IMMEDIATE;',
             'disable' => 'SET CONSTRAINTS ALL DEFERRED;',
         ],

--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -58,6 +58,7 @@ return [
                 'resent'            => 'A new confirmation e-mail has been sent to the address on file.',
             ],
 
+            'registration_not_enabled' => 'This site does not allow self-registration',
             'deactivated' => 'Your account has been deactivated.',
             'email_taken' => 'That e-mail address is already taken.',
 


### PR DESCRIPTION
# FIX
<<<<<<< HEAD
When the .env attribute ENABLE_REGISTRATION is set to false new user accounts could still be created by logging in as a social user.

=======
Sorry could not work out how to split the other two small changes into a seperate request.
One is a duplicate of an existing pull request (needed to get working on postgresql)

The other is just allows a default schema to be set for postgresql in the .env

>>>>>>> release/4.0.0
