### PR TITLE
Add teardown function to test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "private": true,
   "scripts": {
-    "dev": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch-poll": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --watch-poll --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "hot": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "dev": "node node_modules/cross-env/dist/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "node node_modules/cross-env/dist/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch-poll": "node node_modules/cross-env/dist/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --watch-poll --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "hot": "node node_modules/cross-env/dist/bin/cross-env.js NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "node node_modules/cross-env/dist/bin/cross-env.js NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "devDependencies": {
     "axios": "^0.15.3",

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -80,4 +80,13 @@ abstract class BrowserKitTestCase extends BaseTestCase
         $this->executiveRole = Role::find(2);
         $this->userRole = Role::find(3);
     }
+    
+    public function tearDown()
+    {
+        $this->beforeApplicationDestroyed(function () {
+            \DB::disconnect();
+        });
+    
+        parent::tearDown();
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -88,4 +88,13 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $this->executiveRole = Role::find(2);
         $this->userRole = Role::find(3);
     }
+    
+    public function tearDown()
+    {
+        $this->beforeApplicationDestroyed(function () {
+            \DB::disconnect();
+        });
+    
+        parent::tearDown();
+    }
 }


### PR DESCRIPTION
Enhancement for running tests on Gitlab CI.

When running these the tests on Gitlab CI, I experienced the error "Mysql: Too many connection". This was due to the fact that per test, another connection was used. This is now fixed by adding a teardown function to disconnect from the database after the tests. 