### PR TITLE
Fix Truncate table command for Postgres DB

### DIFF
--- a/database/TruncateTable.php
+++ b/database/TruncateTable.php
@@ -20,8 +20,8 @@ trait TruncateTable
             case 'mysql':
                 return DB::table($table)->truncate();
 
-            case 'postgres':
-                return  DB::statement('TRUNCATE TABLE '.$table.' CASCADE');
+            case 'pgsql':
+                return  DB::statement('TRUNCATE TABLE '.$table.' RESTART IDENTITY CASCADE');
 
             case 'sqlite':
                 return DB::statement('DELETE FROM '.$table);


### PR DESCRIPTION
Solve the truncate problem with Postgres and restarting the primary key Identity.


