### PR TITLE
Add size for profile image on Dashboard page

### DIFF
--- a/resources/views/frontend/user/dashboard.blade.php
+++ b/resources/views/frontend/user/dashboard.blade.php
@@ -17,7 +17,7 @@
                             <ul class="media-list">
                                 <li class="media">
                                     <div class="media-left">
-                                        <img class="media-object" src="{{ $logged_in_user->picture }}" alt="Profile picture">
+                                        <img class="media-object" height="90" src="{{ $logged_in_user->picture }}" alt="Profile picture">
                                     </div><!--media-left-->
 
                                     <div class="media-body">


### PR DESCRIPTION
Make sure larger profile images do not break the layout of page

# This is a minor fix.
Constrains the user profile image size on the dashboard page so that it does not break the page layout if the user loads a larger profile image
