### PR TITLE
Replace glob() function usage

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -63,7 +63,7 @@ if (! function_exists('includeRouteFiles')) {
             while($it->valid())
             {
                 if(!$it->isDot() && $it->isFile() && $it->isReadable() && $it->current()->getExtension() === 'php' ){
-                        require_once $it->key();
+                        require $it->key();
                 }
                         
                 /*** move to the next element ***/

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -55,20 +55,23 @@ if (! function_exists('includeRouteFiles')) {
      */
     function includeRouteFiles($folder)
     {
-        $directory = $folder;
-        $handle = opendir($directory);
-        $directory_list = [$directory];
-
-        while (false !== ($filename = readdir($handle))) {
-            if ($filename != '.' && $filename != '..' && is_dir($directory.$filename)) {
-                array_push($directory_list, $directory.$filename.'/');
+        try
+        {
+           $rdi = new recursiveDirectoryIterator($folder);
+           $it = new recursiveIteratorIterator( $rdi );
+            
+            while($it->valid())
+            {
+                if(!$it->isDot() && $it->isFile() && $it->isReadable() && $it->current()->getExtension() === 'php' ){
+                        require_once $it->key();
+                }
+                        
+                /*** move to the next element ***/
+                $it->next();    
             }
-        }
-
-        foreach ($directory_list as $directory) {
-            foreach (glob($directory.'*.php') as $filename) {
-                require $filename;
-            }
+        } catch(Exception $e) {
+                /*** echo the error message ***/
+                echo $e->getMessage();
         }
     }
 }


### PR DESCRIPTION
Since glob() function have unexpected output in some systems it is probably a good idea to replace it with more consistent one (recursiveDirectoryIterator & recursiveIteratorIterator).

This is a fix. Form the official php glob() description it is known that the function have unexpected behaviors like :  

> On some systems it is impossible to distinguish between empty match and an error.

> This function isn't available on some systems (e.g. old Sun OS).

>  The GLOB_BRACE flag is not available on some non GNU systems, like Solaris.

So i have created this function with the more appropriate method to avoid this and other similar issues.

[PHP glob() doc](http://php.net/manual/en/function.glob.php)   
