### PR TITLE
Fix: update of Admin user causes htmlentities error

### DIFF
--- a/resources/views/backend/access/edit.blade.php
+++ b/resources/views/backend/access/edit.blade.php
@@ -112,7 +112,7 @@
         @if ($user->id == 1)
             {{ Form::hidden('status', 1) }}
             {{ Form::hidden('confirmed', 1) }}
-            {{ Form::hidden('assignees_roles[]', 1) }}
+            {{ Form::hidden('assignees_roles[0]', 1) }}
         @endif
 
     {{ Form::close() }}


### PR DESCRIPTION
This problem occurs when a Form field is declared as an array:

{{ Form::hidden('assignees_roles[]', 1) }}

To reproduce, edit user id 1 (Administrator), then blank the name or email field, hit Update. You will get a "htmlentities() expects parameter 1 to be string, array given" error.

Form array fields must have an index to avoid this error.

{{ Form::hidden('assignees_roles[0]', 1) }}