### PR TITLE
Permanently deleting user needs updates to history log

### DIFF
--- a/app/Listeners/Backend/Access/User/UserEventListener.php
+++ b/app/Listeners/Backend/Access/User/UserEventListener.php
@@ -86,7 +86,17 @@ class UserEventListener
             ->withText('trans("history.backend.users.permanently_deleted") <strong>{user}</strong>')
             ->withIcon('trash')
             ->withClass('bg-maroon')
+            ->withAssets([
+                'user_string' => $event->user->name
+            ])
             ->log();
+
+        history()->withType($this->history_slug)
+            ->withEntity($event->user->id)
+            ->withAssets([
+                'user_string' => $event->user->name
+            ])
+            ->updateUserLinkAssets();
     }
 
     /**

--- a/app/Repositories/Backend/History/EloquentHistoryRepository.php
+++ b/app/Repositories/Backend/History/EloquentHistoryRepository.php
@@ -154,6 +154,18 @@ class EloquentHistoryRepository implements HistoryContract
     }
 
     /**
+     * @return mixed
+     */
+    public function updateUserLinkAssets()
+    {
+        return History::where('type_id', $this->type->id)
+            ->where('user_id', access()->id())
+            ->where('entity_id', $this->entity_id)
+            ->where('assets', 'LIKE', '%user_link%')
+            ->update(['assets' => $this->assets]);
+    }
+
+    /**
      * @param null $limit
      * @param bool $paginate
      * @param int  $pagination


### PR DESCRIPTION
To reproduce: Create a new user, delete, then delete permanently. In the Dashboard Recent History it will say "Admin Istrator permanently deleted user {user}" (instead of the actual user name).

This patch will show the correct user name (as plain text, not a link) for all history occurrences.
