### PR TITLE
Standardize use of LaravelCollective formbuilder functions

### DIFF
--- a/app/Http/Requests/Backend/Access/Role/StoreRoleRequest.php
+++ b/app/Http/Requests/Backend/Access/Role/StoreRoleRequest.php
@@ -27,7 +27,7 @@ class StoreRoleRequest extends Request
     public function rules()
     {
         return [
-            'name' => 'required',
+            'name' => 'required|max:191',
         ];
     }
 }

--- a/app/Http/Requests/Backend/Access/Role/UpdateRoleRequest.php
+++ b/app/Http/Requests/Backend/Access/Role/UpdateRoleRequest.php
@@ -27,7 +27,7 @@ class UpdateRoleRequest extends Request
     public function rules()
     {
         return [
-            'name' => 'required',
+            'name' => 'required|max:191',
         ];
     }
 }

--- a/app/Http/Requests/Backend/Access/User/StoreUserRequest.php
+++ b/app/Http/Requests/Backend/Access/User/StoreUserRequest.php
@@ -28,8 +28,8 @@ class StoreUserRequest extends Request
     public function rules()
     {
         return [
-            'name'     => 'required|max:255',
-            'email'    => ['required', 'email', 'max:255', Rule::unique('users')],
+            'name'     => 'required|max:191',
+            'email'    => ['required', 'email', 'max:191', Rule::unique('users')],
             'password' => 'required|min:6|confirmed',
         ];
     }

--- a/app/Http/Requests/Backend/Access/User/UpdateUserRequest.php
+++ b/app/Http/Requests/Backend/Access/User/UpdateUserRequest.php
@@ -27,8 +27,8 @@ class UpdateUserRequest extends Request
     public function rules()
     {
         return [
-            'email' => 'required|email',
-            'name'  => 'required',
+            'email' => 'required|email|max:191',
+            'name'  => 'required|max:191',
         ];
     }
 }

--- a/app/Http/Requests/Frontend/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Frontend/Auth/RegisterRequest.php
@@ -28,8 +28,8 @@ class RegisterRequest extends Request
     public function rules()
     {
         return [
-            'name'                 => 'required|string|max:255',
-            'email'                => ['required', 'string', 'email', 'max:255', Rule::unique('users')],
+            'name'                 => 'required|string|max:191',
+            'email'                => ['required', 'string', 'email', 'max:191', Rule::unique('users')],
             'password'             => 'required|string|min:6|confirmed',
             'g-recaptcha-response' => 'required_if:captcha_status,true|captcha',
         ];

--- a/app/Http/Requests/Frontend/User/UpdateProfileRequest.php
+++ b/app/Http/Requests/Frontend/User/UpdateProfileRequest.php
@@ -27,8 +27,8 @@ class UpdateProfileRequest extends Request
     public function rules()
     {
         return [
-            'name'  => 'required',
-            'email' => 'sometimes|required|email',
+            'name'  => 'required|max:191',
+            'email' => 'sometimes|required|email|max:191',
         ];
     }
 }

--- a/resources/views/backend/access/change-password.blade.php
+++ b/resources/views/backend/access/change-password.blade.php
@@ -26,7 +26,7 @@
                     {{ Form::label('password', trans('validation.attributes.backend.access.users.password'), ['class' => 'col-lg-2 control-label', 'placeholder' => trans('validation.attributes.backend.access.users.password')]) }}
 
                     <div class="col-lg-10">
-                        {{ Form::password('password', ['class' => 'form-control', 'required' => 'required']) }}
+                        {{ Form::password('password', ['class' => 'form-control', 'required' => 'required', 'autofocus' => 'autofocus']) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 

--- a/resources/views/backend/access/change-password.blade.php
+++ b/resources/views/backend/access/change-password.blade.php
@@ -26,7 +26,7 @@
                     {{ Form::label('password', trans('validation.attributes.backend.access.users.password'), ['class' => 'col-lg-2 control-label', 'placeholder' => trans('validation.attributes.backend.access.users.password')]) }}
 
                     <div class="col-lg-10">
-                        {{ Form::password('password', ['class' => 'form-control']) }}
+                        {{ Form::password('password', ['class' => 'form-control', 'required' => 'required']) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 
@@ -34,7 +34,7 @@
                     {{ Form::label('password_confirmation', trans('validation.attributes.backend.access.users.password_confirmation'), ['class' => 'col-lg-2 control-label', 'placeholder' => trans('validation.attributes.backend.access.users.password_confirmation')]) }}
 
                     <div class="col-lg-10">
-                        {{ Form::password('password_confirmation', ['class' => 'form-control']) }}
+                        {{ Form::password('password_confirmation', ['class' => 'form-control', 'required' => 'required']) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
             </div><!-- /.box-body -->

--- a/resources/views/backend/access/create.blade.php
+++ b/resources/views/backend/access/create.blade.php
@@ -26,7 +26,7 @@
                     {{ Form::label('name', trans('validation.attributes.backend.access.users.name'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::text('name', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.name'), 'required' => 'required']) }}
+                        {{ Form::text('name', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.backend.access.users.name')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 
@@ -34,7 +34,7 @@
                     {{ Form::label('email', trans('validation.attributes.backend.access.users.email'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::text('email', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.email'), 'required' => 'required']) }}
+                        {{ Form::email('email', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'placeholder' => trans('validation.attributes.backend.access.users.email')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 
@@ -42,7 +42,7 @@
                     {{ Form::label('password', trans('validation.attributes.backend.access.users.password'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::password('password', ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.password'), 'required' => 'required']) }}
+                        {{ Form::password('password', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.backend.access.users.password')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 
@@ -50,7 +50,7 @@
                     {{ Form::label('password_confirmation', trans('validation.attributes.backend.access.users.password_confirmation'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::password('password_confirmation', ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.password_confirmation'), 'required' => 'required']) }}
+                        {{ Form::password('password_confirmation', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.backend.access.users.password_confirmation')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 

--- a/resources/views/backend/access/edit.blade.php
+++ b/resources/views/backend/access/edit.blade.php
@@ -26,7 +26,7 @@
                     {{ Form::label('name', trans('validation.attributes.backend.access.users.name'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::text('name', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.name'), 'required' => 'required']) }}
+                        {{ Form::text('name', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.backend.access.users.name')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 
@@ -34,7 +34,7 @@
                     {{ Form::label('email', trans('validation.attributes.backend.access.users.email'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::text('email', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.users.email'), 'required' => 'required']) }}
+                        {{ Form::email('email', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'placeholder' => trans('validation.attributes.backend.access.users.email')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 

--- a/resources/views/backend/access/roles/create.blade.php
+++ b/resources/views/backend/access/roles/create.blade.php
@@ -26,7 +26,7 @@
                     {{ Form::label('name', trans('validation.attributes.backend.access.roles.name'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::text('name', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.roles.name')]) }}
+                        {{ Form::text('name', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.backend.access.roles.name')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 

--- a/resources/views/backend/access/roles/edit.blade.php
+++ b/resources/views/backend/access/roles/edit.blade.php
@@ -26,7 +26,7 @@
                     {{ Form::label('name', trans('validation.attributes.backend.access.roles.name'), ['class' => 'col-lg-2 control-label']) }}
 
                     <div class="col-lg-10">
-                        {{ Form::text('name', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.backend.access.roles.name')]) }}
+                        {{ Form::text('name', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.backend.access.roles.name')]) }}
                     </div><!--col-lg-10-->
                 </div><!--form control-->
 

--- a/resources/views/frontend/auth/login.blade.php
+++ b/resources/views/frontend/auth/login.blade.php
@@ -16,14 +16,14 @@
                     <div class="form-group">
                         {{ Form::label('email', trans('validation.attributes.frontend.email'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('email', 'email', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
+                            {{ Form::email('email', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 
                     <div class="form-group">
                         {{ Form::label('password', trans('validation.attributes.frontend.password'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('password', 'password', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.password')]) }}
+                            {{ Form::password('password', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.frontend.password')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 

--- a/resources/views/frontend/auth/passwords/email.blade.php
+++ b/resources/views/frontend/auth/passwords/email.blade.php
@@ -22,7 +22,7 @@
                     <div class="form-group">
                         {{ Form::label('email', trans('validation.attributes.frontend.email'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('email', 'email', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
+                            {{ Form::email('email', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 

--- a/resources/views/frontend/auth/passwords/reset.blade.php
+++ b/resources/views/frontend/auth/passwords/reset.blade.php
@@ -24,21 +24,21 @@
                             {{ Form::label('email', trans('validation.attributes.frontend.email'), ['class' => 'col-md-4 control-label']) }}
                             <div class="col-md-6">
                                 <p class="form-control-static">{{ $email }}</p>
-                                {{ Form::input('hidden', 'email', $email, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
+                                {{ Form::hidden('email', $email, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
                             </div><!--col-md-6-->
                         </div><!--form-group-->
 
                     <div class="form-group">
                         {{ Form::label('password', trans('validation.attributes.frontend.password'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('password', 'password', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.password')]) }}
+                            {{ Form::password('password', ['class' => 'form-control', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.frontend.password')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 
                     <div class="form-group">
                         {{ Form::label('password_confirmation', trans('validation.attributes.frontend.password_confirmation'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('password', 'password_confirmation', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.password_confirmation')]) }}
+                            {{ Form::password('password_confirmation', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.frontend.password_confirmation')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 

--- a/resources/views/frontend/auth/register.blade.php
+++ b/resources/views/frontend/auth/register.blade.php
@@ -15,28 +15,28 @@
                     <div class="form-group">
                         {{ Form::label('name', trans('validation.attributes.frontend.name'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('name', 'name', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.name')]) }}
+                            {{ Form::text('name', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.frontend.name')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 
                     <div class="form-group">
                         {{ Form::label('email', trans('validation.attributes.frontend.email'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('email', 'email', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
+                            {{ Form::email('email', null, ['class' => 'form-control', 'maxlength' => '191', 'required' => 'required', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 
                     <div class="form-group">
                         {{ Form::label('password', trans('validation.attributes.frontend.password'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('password', 'password', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.password')]) }}
+                            {{ Form::password('password', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.frontend.password')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 
                     <div class="form-group">
                         {{ Form::label('password_confirmation', trans('validation.attributes.frontend.password_confirmation'), ['class' => 'col-md-4 control-label']) }}
                         <div class="col-md-6">
-                            {{ Form::input('password', 'password_confirmation', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.password_confirmation')]) }}
+                            {{ Form::password('password_confirmation', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.frontend.password_confirmation')]) }}
                         </div><!--col-md-6-->
                     </div><!--form-group-->
 

--- a/resources/views/frontend/user/account/tabs/change-password.blade.php
+++ b/resources/views/frontend/user/account/tabs/change-password.blade.php
@@ -3,21 +3,21 @@
     <div class="form-group">
         {{ Form::label('old_password', trans('validation.attributes.frontend.old_password'), ['class' => 'col-md-4 control-label']) }}
         <div class="col-md-6">
-            {{ Form::input('password', 'old_password', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.old_password')]) }}
+            {{ Form::password('old_password', ['class' => 'form-control', 'required' => 'required', 'autofocus' => 'autofocus', 'placeholder' => trans('validation.attributes.frontend.old_password')]) }}
         </div>
     </div>
 
     <div class="form-group">
         {{ Form::label('password', trans('validation.attributes.frontend.new_password'), ['class' => 'col-md-4 control-label']) }}
         <div class="col-md-6">
-            {{ Form::input('password', 'password', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.new_password')]) }}
+            {{ Form::password('password', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.frontend.new_password')]) }}
         </div>
     </div>
 
     <div class="form-group">
         {{ Form::label('password_confirmation', trans('validation.attributes.frontend.new_password_confirmation'), ['class' => 'col-md-4 control-label']) }}
         <div class="col-md-6">
-            {{ Form::input('password', 'password_confirmation', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.new_password_confirmation')]) }}
+            {{ Form::password('password_confirmation', ['class' => 'form-control', 'required' => 'required', 'placeholder' => trans('validation.attributes.frontend.new_password_confirmation')]) }}
         </div>
     </div>
 

--- a/resources/views/frontend/user/account/tabs/edit.blade.php
+++ b/resources/views/frontend/user/account/tabs/edit.blade.php
@@ -3,7 +3,7 @@
     <div class="form-group">
         {{ Form::label('name', trans('validation.attributes.frontend.name'), ['class' => 'col-md-4 control-label']) }}
         <div class="col-md-6">
-            {{ Form::input('text', 'name', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.name')]) }}
+            {{ Form::text('name', null, ['class' => 'form-control', 'required' => 'required', 'autofocus' => 'autofocus', 'maxlength' => '191', 'placeholder' => trans('validation.attributes.frontend.name')]) }}
         </div>
     </div>
 
@@ -15,7 +15,7 @@
                     <i class="fa fa-info-circle"></i> {{  trans('strings.frontend.user.change_email_notice') }}
                 </div>
 
-                {{ Form::input('email', 'email', null, ['class' => 'form-control', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
+                {{ Form::email('email', null, ['class' => 'form-control', 'required' => 'required', 'maxlength' => '191', 'placeholder' => trans('validation.attributes.frontend.email')]) }}
             </div>
         </div>
     @endif


### PR DESCRIPTION
On the front end this PR changes all Form::input() calls to the more specific Form:name(), Form::email() and Form::password(). In addition it makes required fields actually be required, sets autofocus to the first field on a form, and sets maxlength for name and email fields.

On the backend name and email fields are limited to a max length of 191 characters.

The maxlength is due to a change in Laravel 5.4, as described here:
https://laravel-news.com/laravel-5-4-key-too-long-error

string fields like name and email are now defined in MySQL as varchar(191) utf8mb4_unicode_ci.

Passing more than 191 characters to the db for fields defined this way throws a "String data, right truncated: 1406 Data too long for column" error.

Although in practice it may be unlikely to see this error as most users will not choose a username or have an email address longer than 191 characters, it should serve as a reminder that all string fields should be limited in length on the front and back end.
