### PR TITLE
Enhancement: add redirectToHome() which depends on user login status

### DIFF
--- a/app/Http/Controllers/Backend/Access/User/UserAccessController.php
+++ b/app/Http/Controllers/Backend/Access/User/UserAccessController.php
@@ -37,7 +37,7 @@ class UserAccessController extends Controller
             access()->loginUsingId($user->id);
 
             // Redirect.
-            return redirect()->route('frontend.index');
+            return redirectToHome();
         }
 
         app()->make(Auth::class)->flushTempSession();
@@ -55,7 +55,6 @@ class UserAccessController extends Controller
         // Login user
         access()->loginUsingId($user->id);
 
-        // Redirect to frontend
-        return redirect()->route('frontend.index');
+        return redirectToHome();
     }
 }

--- a/app/Http/Controllers/Frontend/Auth/RegisterController.php
+++ b/app/Http/Controllers/Frontend/Auth/RegisterController.php
@@ -28,7 +28,7 @@ class RegisterController extends Controller
     public function __construct(UserRepository $user)
     {
         // Where to redirect users after registering
-        $this->redirectTo = route('frontend.index');
+        $this->redirectTo = homeRoute();
 
         $this->user = $user;
     }

--- a/app/Http/Controllers/Frontend/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Frontend/Auth/ResetPasswordController.php
@@ -36,7 +36,7 @@ class ResetPasswordController extends Controller
      */
     public function redirectPath()
     {
-        return route('frontend.index');
+        return homeRoute();
     }
 
     /**

--- a/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
@@ -52,7 +52,7 @@ class SocialLoginController extends Controller
 
         // If the provider is not an acceptable third party than kick back
         if (! in_array($provider, $this->helper->getAcceptedProviders())) {
-            return redirect()->route('frontend.index')->withFlashDanger(trans('auth.socialite.unacceptable', ['provider' => $provider]));
+            return redirectToHome(trans('auth.socialite.unacceptable', ['provider' => $provider]));
         }
 
         /*
@@ -68,11 +68,12 @@ class SocialLoginController extends Controller
         try {
             $user = $this->user->findOrCreateSocial($this->getSocialUser($provider), $provider);
         } catch (GeneralException $e) {
-            return redirect()->route('frontend.index')->withFlashDanger($e->getMessage());
+            return redirectToHome($e->getMessage());
+
         }
 
         if (is_null($user) || ! isset($user)) {
-            return redirect()->route('frontend.index')->withFlashDanger(trans('exceptions.frontend.auth.unknown'));
+            return redirectToHome(trans('exceptions.frontend.auth.unknown'));
         }
 
         // Check to see if they are active.
@@ -90,7 +91,7 @@ class SocialLoginController extends Controller
         session([config('access.socialite_session_name') => $provider]);
 
         // Return to the intended url or default to the class property
-        return redirect()->intended(route('frontend.index'));
+        return redirect()->intended(homeRoute());
     }
 
     /**

--- a/app/Http/Middleware/RouteNeedsPermission.php
+++ b/app/Http/Middleware/RouteNeedsPermission.php
@@ -33,9 +33,7 @@ class RouteNeedsPermission
         }
 
         if (! $access) {
-            return redirect()
-                ->route('frontend.index')
-                ->withFlashDanger(trans('auth.general_error'));
+            return redirectToHome(trans('auth.general_error'));
         }
 
         return $next($request);

--- a/app/Http/Middleware/RouteNeedsRole.php
+++ b/app/Http/Middleware/RouteNeedsRole.php
@@ -33,9 +33,7 @@ class RouteNeedsRole
         }
 
         if (! $access) {
-            return redirect()
-                ->route('frontend.index')
-                ->withFlashDanger(trans('auth.general_error'));
+            return redirectToHome(trans('auth.general_error'));
         }
 
         return $next($request);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Auth;
+
 /**
  * Global helpers file with misc functions.
  */
@@ -91,5 +93,49 @@ if (! function_exists('getRtlCss')) {
         $filename = rtrim($filename, '.css');
 
         return implode('/', $path).'/'.$filename.'.rtl.css';
+    }
+}
+
+if (! function_exists('redirectToHome')) {
+    /**
+     * Redirect to the "home" page.
+     */
+    function redirectToHome($flashMsg = null, $arr = null)
+    {
+        $route = null;
+        if (access()->allow('view-backend')) {
+            $route = 'admin.dashboard';
+        } else if (Auth::check()) {
+            $route = 'frontend.user.dashboard';
+        }
+
+        if ($route) {
+            if ($flashMsg) {
+                return redirect()->route($route)->withFlashDanger($flashMsg, $arr);
+            } else {
+                return redirect()->route($route);
+            }
+        }
+
+        if ($flashMsg) {
+            return redirect()->route('frontend.index')->withFlashDanger($flashMsg, $arr);
+        }
+
+        return redirect()->route('frontend.index');
+    }
+}
+
+if (! function_exists('homeRoute')) {
+    /**
+     * Return the route to the "home" page.
+     */
+    function homeRoute()
+    {
+        if (access()->allow('view-backend')) {
+            return route('admin.dashboard');
+        } else if (Auth::check()) {
+            return route('frontend.user.dashboard');
+        }
+        return route('frontend.index');
     }
 }


### PR DESCRIPTION
It seems to me that once a user is logged in their "home" page is their user or admin dashboard. 

This PR will direct users to the correct place as determined by their login status after actions occur such as role or permission failure, loginAs()  a different user, etc.

For example, when logged in as a user without backend access, attempting to navigate to /admin/dashboard should take you back to /dashboard with the "You do not have access to do that" message.