### PR TITLE
Password reset improvement

### DIFF
--- a/app/Http/Controllers/Frontend/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Frontend/Auth/ResetPasswordController.php
@@ -50,8 +50,20 @@ class ResetPasswordController extends Controller
      */
     public function showResetForm($token = null)
     {
-        return view('frontend.auth.passwords.reset')
-            ->withToken($token)
-            ->withEmail($this->user->getEmailForPasswordToken($token));
+        if (! $token)
+            return redirect()->route('frontend.auth.password.email');
+
+        $user = $this->user->findByPasswordResetToken($token);
+
+        if ($user) {
+            if (app()->make('auth.password.broker')->tokenExists($user, $token)) {
+                return view('frontend.auth.passwords.reset')
+                    ->withToken($token)
+                    ->withEmail($user->email);
+            }
+        }
+
+        return redirect()->route('frontend.auth.password.email')
+            ->withFlashWarning('There was a problem resetting your password. Please resend the password reset email.');
     }
 }

--- a/app/Http/Controllers/Frontend/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Frontend/Auth/ResetPasswordController.php
@@ -50,8 +50,9 @@ class ResetPasswordController extends Controller
      */
     public function showResetForm($token = null)
     {
-        if (! $token)
+        if (! $token) {
             return redirect()->route('frontend.auth.password.email');
+        }
 
         $user = $this->user->findByPasswordResetToken($token);
 

--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -38,7 +38,7 @@ class UserRepository extends BaseRepository
     /**
      * @param $email
      *
-     * @return bool
+     * @return mixed
      */
     public function findByEmail($email)
     {
@@ -55,6 +55,26 @@ class UserRepository extends BaseRepository
     public function findByToken($token)
     {
         return $this->query()->where('confirmation_code', $token)->first();
+    }
+
+    /**
+     * @param $token
+     *
+     * @return mixed
+     */
+    public function findByPasswordResetToken($token)
+    {
+        $rows = DB::table(config('auth.passwords.users.table'))->get();
+
+        $user = null;
+        foreach ($rows as $row) {
+            if (password_verify($token, $row->token)) {
+                $user = $this->findByEmail($row->email);
+                break;
+            }
+        }
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
Currently when a user submits the password reset form and the token has expired, they get the message "This password reset token is invalid", but they are still on the password reset form, with no idea what to do next. They should be given a better message and taken to the form where they can re-send the password reset email.

To reproduce:

In config/auth.php set passwords.users.expire to 1 (1 minute).

Now send yourself two password reset emails. Click on the first one received and you will get "An unknown error occurred", but fortunately it shows the "Reset Password" form so you can send another password reset email.

Now click on the second password reset link. Assuming the token has expired, **after** submitting the form it will tell you "This password reset token is invalid" and remains on the password reset form. It should redirect to the password reset send email link form.

This PR tells the user right away before even submitting the form there is a problem with the token, so they can resend the reset email.