### PR TITLE
Fix: Add Source Sans Pro font import

### DIFF
--- a/resources/assets/sass/backend/app.scss
+++ b/resources/assets/sass/backend/app.scss
@@ -1,3 +1,6 @@
+// Fonts
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700,700i);
+
 @import "variable-overrides";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap";
 @import "~font-awesome/scss/font-awesome";


### PR DESCRIPTION
The Source Sans Pro font is referenced in several places in the backend.