### PR TITLE
Only version the js and css when compiling for production

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -28,5 +28,8 @@ mix.sass('resources/assets/sass/frontend/app.scss', 'public/css/frontend.css')
         plugins: [
             new WebpackRTLPlugin('/css/[name].rtl.css')
         ]
-    })
-    .version();
+    });
+
+if(mix.config.inProduction){
+    mix.version();
+}


### PR DESCRIPTION
This pull request prevents excess generated JS and CSS while in development mode.

In the code currently, `npm run dev` will generate .js and .css files with a version appended to the end of the filename. Since each new compile is versioned, new files created and the public/css & public/js are filled with unnecessary files. This pull request implements what's suggested in the Laravel Docs [https://laravel.com/docs/5.4/mix#versioning-and-cache-busting](https://laravel.com/docs/5.4/mix#versioning-and-cache-busting) and only utilizes versioning when compiling for production. Dev compiles will reuse the same files each compile.