### PR TITLE
Separate First name and Last name when using Social Login

### DIFF
--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -137,6 +137,38 @@ class UserRepository extends BaseRepository
     }
 
     /**
+    * @param $fullName
+    *
+    * @return array
+    */
+    protected function getFirstLastNames($fullName)
+    {
+        $parts = array_values(array_filter(explode(" ", $fullName)));
+
+        $size = count($parts);
+
+        $result = [];
+
+        if(empty($parts)){
+            $result['first_name']   = NULL;
+            $result['last_name']    = NULL;
+        }
+
+        if(!empty($parts) && $size == 1){
+            $result['first_name']   = $parts[0];
+            $result['last_name']    = NULL;
+        }
+
+        if(!empty($parts) && $size >= 2){
+            $result['first_name']   = $parts[0];
+            $result['last_name']    = $parts[1];
+        }
+
+        return $result;
+    }
+	
+    
+    /**
      * @param $data
      * @param $provider
      *
@@ -161,10 +193,13 @@ class UserRepository extends BaseRepository
             if (! config('access.users.registration')) {
                 throw new GeneralException(trans('exceptions.frontend.auth.registration_disabled'));
             }
-
+            
+            // Get users first name and last name.
+			$userFirstLastName = $this->getFirstLastNames($data->getName());
+            
             $user = $this->create([
-                'first_name'  => $data->first_name,
-                'last_name'  => $data->last_name,
+                'first_name'  => $userFirstLastName['first_name'],
+                'last_name'  => $userFirstLastName['last_name'],
                 'email' => $user_email,
             ], true);
         }

--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -143,31 +143,30 @@ class UserRepository extends BaseRepository
     */
     protected function getFirstLastNames($fullName)
     {
-        $parts = array_values(array_filter(explode(" ", $fullName)));
+        $parts = array_values(array_filter(explode(' ', $fullName)));
 
         $size = count($parts);
 
         $result = [];
 
-        if(empty($parts)){
-            $result['first_name']   = NULL;
-            $result['last_name']    = NULL;
+        if (empty($parts)) {
+            $result['first_name'] = null;
+            $result['last_name'] = null;
         }
 
-        if(!empty($parts) && $size == 1){
-            $result['first_name']   = $parts[0];
-            $result['last_name']    = NULL;
+        if (! empty($parts) && $size == 1) {
+            $result['first_name'] = $parts[0];
+            $result['last_name'] = null;
         }
 
-        if(!empty($parts) && $size >= 2){
-            $result['first_name']   = $parts[0];
-            $result['last_name']    = $parts[1];
+        if (! empty($parts) && $size >= 2) {
+            $result['first_name'] = $parts[0];
+            $result['last_name'] = $parts[1];
         }
 
         return $result;
     }
 	
-    
     /**
      * @param $data
      * @param $provider
@@ -195,7 +194,7 @@ class UserRepository extends BaseRepository
             }
             
             // Get users first name and last name.
-	    $userFirstLastName = $this->getFirstLastNames($data->getName());
+            $userFirstLastName = $this->getFirstLastNames($data->getName());
             
             $user = $this->create([
                 'first_name'  => $userFirstLastName['first_name'],

--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -195,7 +195,7 @@ class UserRepository extends BaseRepository
             }
             
             // Get users first name and last name.
-			$userFirstLastName = $this->getFirstLastNames($data->getName());
+	    $userFirstLastName = $this->getFirstLastNames($data->getName());
             
             $user = $this->create([
                 'first_name'  => $userFirstLastName['first_name'],


### PR DESCRIPTION
Separate First name and Last name when using Social Login and user does not exist.

Works and Tested with BitBucket, Facebook, Google, GitHub, LinkedIn and Twitter. Atleast with my name it works. I don't know how it feels when people have more than two first names or last names.

Credit to christostsang - http://stackoverflow.com/questions/32407604/laravel-socialite-first-and-last-name