### PR TITLE
Add ability for admins to manually approve accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@ SESSION_TIMEOUT=600
 
 # Access
 ENABLE_REGISTRATION=true
+AUTO_SEND_CONFIRMATION=true
 
 # Get your credentials at: https://www.google.com/recaptcha/admin
 REGISTRATION_CAPTCHA_STATUS=false

--- a/app/Http/Controllers/Frontend/Auth/LoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/LoginController.php
@@ -58,7 +58,7 @@ class LoginController extends Controller
          */
         if (! $user->isConfirmed()) {
             access()->logout();
-             $msg = (config('access.users.auto_send_confirmation')) ? trans("exceptions.frontend.auth.confirmation.pending") : trans('exceptions.frontend.auth.confirmation.resend', ['user_id' => $user->id]);
+         	$msg = (config('access.users.auto_send_confirmation')) ? trans("exceptions.frontend.auth.confirmation.pending") : trans('exceptions.frontend.auth.confirmation.resend', ['user_id' => $user->id]);
             throw new GeneralException($msg);
         } elseif (! $user->isActive()) {
             access()->logout();

--- a/app/Http/Controllers/Frontend/Auth/LoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/LoginController.php
@@ -58,7 +58,8 @@ class LoginController extends Controller
          */
         if (! $user->isConfirmed()) {
             access()->logout();
-            throw new GeneralException(trans('exceptions.frontend.auth.confirmation.resend', ['user_id' => $user->id]));
+             $msg = (config('access.users.auto_send_confirmation')) ? trans("exceptions.frontend.auth.confirmation.pending") : trans('exceptions.frontend.auth.confirmation.resend', ['user_id' => $user->id]);
+            throw new GeneralException($msg);
         } elseif (! $user->isActive()) {
             access()->logout();
             throw new GeneralException(trans('exceptions.frontend.auth.deactivated'));

--- a/app/Http/Controllers/Frontend/Auth/RegisterController.php
+++ b/app/Http/Controllers/Frontend/Auth/RegisterController.php
@@ -50,7 +50,7 @@ class RegisterController extends Controller
      */
     public function register(RegisterRequest $request)
     {
-        if (config('access.users.confirm_email')) {
+        if (config('access.users.confirm_email')|| config('access.users.auto_send_confirmation')) {
             $user = $this->user->create($request->all());
             event(new UserRegistered($user));
 			$msg = (config('access.users.auto_send_confirmation')) ? trans('exceptions.frontend.auth.confirmation.created_confirm'): trans('exceptions.frontend.auth.confirmation.created_pending') ;

--- a/app/Http/Controllers/Frontend/Auth/RegisterController.php
+++ b/app/Http/Controllers/Frontend/Auth/RegisterController.php
@@ -50,7 +50,7 @@ class RegisterController extends Controller
      */
     public function register(RegisterRequest $request)
     {
-        if (config('access.users.confirm_email')|| config('access.users.auto_send_confirmation')) {
+        if (config('access.users.confirm_email') || config('access.users.auto_send_confirmation')) {
             $user = $this->user->create($request->all());
             event(new UserRegistered($user));
 			$msg = (config('access.users.auto_send_confirmation')) ? trans('exceptions.frontend.auth.confirmation.created_confirm'): trans('exceptions.frontend.auth.confirmation.created_pending') ;

--- a/app/Http/Controllers/Frontend/Auth/RegisterController.php
+++ b/app/Http/Controllers/Frontend/Auth/RegisterController.php
@@ -53,8 +53,8 @@ class RegisterController extends Controller
         if (config('access.users.confirm_email')) {
             $user = $this->user->create($request->all());
             event(new UserRegistered($user));
-
-            return redirect($this->redirectPath())->withFlashSuccess(trans('exceptions.frontend.auth.confirmation.created_confirm'));
+			$msg = (config('access.users.auto_send_confirmation')) ? trans('exceptions.frontend.auth.confirmation.created_confirm'): trans('exceptions.frontend.auth.confirmation.created_pending') ;
+            return redirect($this->redirectPath())->withFlashSuccess($msg);
         } else {
             auth()->login($this->user->create($request->all()));
             event(new UserRegistered(access()->user()));

--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -104,7 +104,7 @@ class UserRepository extends Repository
          *
          * If this is a social account they are confirmed through the social provider by default
          */
-        if (config('access.users.confirm_email') && $provider === false) {
+        if (config('access.users.confirm_email') && $provider === false && config('access.users.auto_send_confirmation')) {
             $user->notify(new UserNeedsConfirmation($user->confirmation_code));
         }
 

--- a/config/access.php
+++ b/config/access.php
@@ -64,6 +64,11 @@ return [
          * Whether or not the users email can be changed on the edit profile screen
          */
         'change_email' => false,
+        /*
+         * Used to disable emails being sent out to confirm their account.
+         * Allows admins to manually confirm accounts.
+         */
+        'auto_send_confirmation' => env("AUTO_SEND_CONFIRMATION", true),
     ],
 
     /*

--- a/config/access.php
+++ b/config/access.php
@@ -68,7 +68,7 @@ return [
          * Used to disable emails being sent out to confirm their account.
          * Allows admins to manually confirm accounts.
          */
-        'auto_send_confirmation' => env("AUTO_SEND_CONFIRMATION", true),
+        'auto_send_confirmation' => env('AUTO_SEND_CONFIRMATION', true),
     ],
 
     /*

--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -51,6 +51,7 @@ return [
                 'already_confirmed' => 'Your account is already confirmed.',
                 'confirm'           => 'Confirm your account!',
                 'created_confirm'   => 'Your account was successfully created. We have sent you an e-mail to confirm your account.',
+                'created_pending'   => 'Your account was successfully created and pending approval. An email will be sent when your account is approved.',
                 'mismatch'          => 'Your confirmation code does not match.',
                 'not_found'         => 'That confirmation code does not exist.',
                 'resend'            => 'Your account is not confirmed. Please click the confirmation link in your e-mail, or <a href="'.route('frontend.auth.account.confirm.resend', ':user_id').'">click here</a> to resend the confirmation e-mail.',

--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -54,6 +54,7 @@ return [
                 'created_pending'   => 'Your account was successfully created and pending approval. An email will be sent when your account is approved.',
                 'mismatch'          => 'Your confirmation code does not match.',
                 'not_found'         => 'That confirmation code does not exist.',
+                'pending'            => 'Your account is currently pending approval.',
                 'resend'            => 'Your account is not confirmed. Please click the confirmation link in your e-mail, or <a href="'.route('frontend.auth.account.confirm.resend', ':user_id').'">click here</a> to resend the confirmation e-mail.',
                 'success'           => 'Your account has been successfully confirmed!',
                 'resent'            => 'A new confirmation e-mail has been sent to the address on file.',


### PR DESCRIPTION
Added new configurations flags that disable the ability to automatically send emails
for users to confirm their account. Useful for when the admin wants to manually
approve each account. 

When confirm email flag is set to false, and the new flag is set to true, it will still show a pending message to users.