### PR TITLE
Changed default permission in Request, override failedAuthorization

### DIFF
--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use App\Exceptions\GeneralException;
+use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Class Request.
@@ -16,7 +16,6 @@ abstract class Request extends FormRequest
     protected $error = '';
 
     /**
-     *
      * @throws GeneralException
      */
     protected function failedAuthorization()

--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Exceptions\GeneralException;
 
 /**
  * Class Request.
@@ -15,14 +16,15 @@ abstract class Request extends FormRequest
     protected $error = '';
 
     /**
-     * @return $this
+     *
+     * @throws GeneralException
      */
-    public function forbiddenResponse()
+    protected function failedAuthorization()
     {
-        if (empty($error)) {
+        if (empty($this->error)) {
             $this->error = trans('auth.general_error');
         }
 
-        return redirect()->back()->withErrors($this->error);
+        throw new GeneralException($this->error);
     }
 }


### PR DESCRIPTION
The old method `forbiddenResponse` was replaced with `failedAuthorization` as per [commit](https://github.com/laravel/framework/commit/1a7540967ca36f875a262a22b76c2a094b9ba3b4). 
