### PR TITLE
Sidebar menu

### DIFF
--- a/app/Http/Composers/Backend/SidebarComposer.php
+++ b/app/Http/Composers/Backend/SidebarComposer.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Composers\Backend;
 
-use Spatie\Menu\Link;
 use Illuminate\View\View;
-use Spatie\Menu\Laravel\Menu;
+use App\Services\Menu\Menu;
 use App\Repositories\Backend\Access\User\UserRepository;
 
 /**
@@ -16,95 +15,22 @@ class SidebarComposer
      * @var UserRepository
      */
     protected $userRepository;
-
     /**
-     * @var Menu
+     * @var \Spatie\Menu\Laravel\Menu
      */
     protected $menu;
+
     /**
      * SidebarComposer constructor.
      *
      * @param UserRepository $userRepository
+     * @param Menu           $menu
      */
-    public function __construct(UserRepository $userRepository)
+    public function __construct(UserRepository $userRepository, Menu $menu)
     {
         $this->userRepository = $userRepository;
-        $this->menu = Menu::new()
-            ->addClass('sidebar-menu')
-
-            //General
-            ->html('General', ['class'=>'header'])
-            ->add(Link::to(
-                route('admin.dashboard'),
-                self::placeIcon('dashboard', trans('menus.backend.sidebar.dashboard'))
-            ))
-
-            //System
-            ->html(trans('menus.backend.sidebar.system'), ['class'=>'header'])
-            ->submenuIf(
-                access()->hasRole("1"),
-                Link::to(
-                    '#',
-                    self::placeIcon(
-                        'users',
-                        trans('labels.backend.access.users.management')
-                    ) . '<i class="fa fa-angle-left pull-right"></i>'
-                ),
-                Menu::new()
-                    ->addClass('treeview-menu')
-                    ->add(Link::to(
-                        route('admin.access.user.index'),
-                        self::placeIcon(
-                            'circle-o',
-                            trans('labels.backend.access.users.management')
-                        )
-                    ))
-                    ->add(Link::to(
-                        route('admin.access.role.index'),
-                        self::placeIcon(
-                            'circle-o',
-                            trans('labels.backend.access.roles.management')
-                        )
-                    ))
-            )
-            ->submenu(
-                Link::to(
-                    '#',
-                    self::placeIcon(
-                        'list',
-                        trans('menus.backend.log-viewer.main')
-                    ) . '<i class="fa fa-angle-left pull-right"></i>'
-                ),
-                Menu::new()
-                    ->addClass('treeview-menu')
-                    ->add(Link::to(
-                        route('log-viewer::dashboard'),
-                        self::placeIcon(
-                            'circle-o',
-                            trans('menus.backend.log-viewer.dashboard')
-                        )
-                    ))
-                    ->add(Link::to(
-                        route('log-viewer::logs.list'),
-                        self::placeIcon(
-                            'circle-o',
-                            trans('menus.backend.log-viewer.logs')
-                        )
-                    ))
-            )->setActive(url()->current());
+        $this->menu = $menu->getMenu();
     }
-
-    /**
-     * @param string $icon
-     * @param string $text
-     * @return string
-     */
-
-    private function placeIcon(string $icon, string $text)
-    {
-        return("<i class=\"fa fa-{$icon}\"></i><span>{$text}</span>");
-    }
-
     /**
      * @param View $view
      *
@@ -112,10 +38,6 @@ class SidebarComposer
      */
     public function compose(View $view)
     {
-        if (config('access.users.requires_approval')) {
-            $view->with('pending_approval', $this->userRepository->getUnconfirmedCount())->with('menu', $this->menu);
-        } else {
-            $view->with('pending_approval', 0)->with('menu', $this->menu);
-        }
+        $view->with('menu', $this->menu);
     }
 }

--- a/app/Http/Composers/Backend/SidebarComposer.php
+++ b/app/Http/Composers/Backend/SidebarComposer.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Composers\Backend;
 
+use Spatie\Menu\Link;
 use Illuminate\View\View;
+use Spatie\Menu\Laravel\Menu;
 use App\Repositories\Backend\Access\User\UserRepository;
 
 /**
@@ -16,6 +18,10 @@ class SidebarComposer
     protected $userRepository;
 
     /**
+     * @var Menu
+     */
+    protected $menu;
+    /**
      * SidebarComposer constructor.
      *
      * @param UserRepository $userRepository
@@ -23,6 +29,80 @@ class SidebarComposer
     public function __construct(UserRepository $userRepository)
     {
         $this->userRepository = $userRepository;
+        $this->menu = Menu::new()
+            ->addClass('sidebar-menu')
+
+            //General
+            ->html('General', ['class'=>'header'])
+            ->add(Link::to(
+                route('admin.dashboard'),
+                self::placeIcon('dashboard', trans('menus.backend.sidebar.dashboard'))
+            ))
+
+            //System
+            ->html(trans('menus.backend.sidebar.system'), ['class'=>'header'])
+            ->submenuIf(
+                access()->hasRole("1"),
+                Link::to(
+                    '#',
+                    self::placeIcon(
+                        'users',
+                        trans('labels.backend.access.users.management')
+                    ) . '<i class="fa fa-angle-left pull-right"></i>'
+                ),
+                Menu::new()
+                    ->addClass('treeview-menu')
+                    ->add(Link::to(
+                        route('admin.access.user.index'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('labels.backend.access.users.management')
+                        )
+                    ))
+                    ->add(Link::to(
+                        route('admin.access.role.index'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('labels.backend.access.roles.management')
+                        )
+                    ))
+            )
+            ->submenu(
+                Link::to(
+                    '#',
+                    self::placeIcon(
+                        'list',
+                        trans('menus.backend.log-viewer.main')
+                    ) . '<i class="fa fa-angle-left pull-right"></i>'
+                ),
+                Menu::new()
+                    ->addClass('treeview-menu')
+                    ->add(Link::to(
+                        route('log-viewer::dashboard'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('menus.backend.log-viewer.dashboard')
+                        )
+                    ))
+                    ->add(Link::to(
+                        route('log-viewer::logs.list'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('menus.backend.log-viewer.logs')
+                        )
+                    ))
+            )->setActive(url()->current());
+    }
+
+    /**
+     * @param string $icon
+     * @param string $text
+     * @return string
+     */
+
+    private function placeIcon(string $icon, string $text)
+    {
+        return("<i class=\"fa fa-{$icon}\"></i><span>{$text}</span>");
     }
 
     /**
@@ -33,9 +113,9 @@ class SidebarComposer
     public function compose(View $view)
     {
         if (config('access.users.requires_approval')) {
-            $view->with('pending_approval', $this->userRepository->getUnconfirmedCount());
+            $view->with('pending_approval', $this->userRepository->getUnconfirmedCount())->with('menu', $this->menu);
         } else {
-            $view->with('pending_approval', 0);
+            $view->with('pending_approval', 0)->with('menu', $this->menu);
         }
     }
 }

--- a/app/Http/Composers/Backend/SidebarComposer.php
+++ b/app/Http/Composers/Backend/SidebarComposer.php
@@ -15,6 +15,7 @@ class SidebarComposer
      * @var UserRepository
      */
     protected $userRepository;
+
     /**
      * @var \Spatie\Menu\Laravel\Menu
      */
@@ -31,6 +32,7 @@ class SidebarComposer
         $this->userRepository = $userRepository;
         $this->menu = $menu->getMenu();
     }
+
     /**
      * @param View $view
      *

--- a/app/Services/Menu/Menu.php
+++ b/app/Services/Menu/Menu.php
@@ -2,18 +2,15 @@
 
 namespace App\Services\Menu;
 
-use App\Repositories\Backend\Access\User\UserRepository;
 use Spatie\Menu\Laravel\Link;
 use Spatie\Menu\Laravel\Menu as LaravelMenu;
+use App\Repositories\Backend\Access\User\UserRepository;
 
 /**
  * Class Menu
- *
- * @package App\Services\Menu
  */
 class Menu
 {
-
     /**
      * @var UserRepository
      */
@@ -28,7 +25,6 @@ class Menu
     {
         $this->userRepository = $userRepository;
     }
-
 
     public function getMenu()
     {
@@ -45,13 +41,13 @@ class Menu
             //System
             ->html(trans('menus.backend.sidebar.system'), ['class'=>'header'])
             ->submenuIf(
-                access()->hasRole("1"),
+                access()->hasRole('1'),
                 Link::to(
                     '#',
                     self::placeIcon(
                         'users',
                         trans('labels.backend.access.users.management')
-                    ) . self::pendingApproval()
+                    ).self::pendingApproval()
                 ),
                 LaravelMenu::new()
                     ->addClass('treeview-menu')
@@ -60,7 +56,7 @@ class Menu
                         self::placeIcon(
                             'circle-o',
                             trans('labels.backend.access.users.management')
-                        ) . self::pendingApproval()
+                        ).self::pendingApproval()
                     ))
                     ->add(Link::to(
                         route('admin.access.role.index'),
@@ -76,7 +72,7 @@ class Menu
                     self::placeIcon(
                         'list',
                         trans('menus.backend.log-viewer.main')
-                    ) . '<i class="fa fa-angle-left pull-right"></i>'
+                    ).'<i class="fa fa-angle-left pull-right"></i>'
                 ),
                 LaravelMenu::new()
                     ->addClass('treeview-menu')
@@ -104,7 +100,7 @@ class Menu
      */
     private function placeIcon(string $icon, string $text)
     {
-        return("<i class=\"fa fa-{$icon}\"></i><span>{$text}</span>");
+        return "<i class=\"fa fa-{$icon}\"></i><span>{$text}</span>";
     }
 
     /**
@@ -112,10 +108,10 @@ class Menu
      */
     private function pendingApproval()
     {
-        if ( config('access.users.requires_approval') && $this->userRepository->getUnconfirmedCount() > 0 ) {
+        if (config('access.users.requires_approval') && $this->userRepository->getUnconfirmedCount() > 0) {
             return "<span class=\"label label-danger pull-right\">{$this->userRepository->getUnconfirmedCount()}</span>";
         } else {
-            return "<i class=\"fa fa-angle-left pull-right\"></i>";
+            return '<i class="fa fa-angle-left pull-right"></i>';
         }
     }
 }

--- a/app/Services/Menu/Menu.php
+++ b/app/Services/Menu/Menu.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Services\Menu;
+
+use App\Repositories\Backend\Access\User\UserRepository;
+use Spatie\Menu\Laravel\Link;
+use Spatie\Menu\Laravel\Menu as LaravelMenu;
+
+/**
+ * Class Menu
+ *
+ * @package App\Services\Menu
+ */
+class Menu
+{
+
+    /**
+     * @var UserRepository
+     */
+    protected $userRepository;
+
+    /**
+     * Menu constructor.
+     *
+     * @param $userRepository
+     */
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+    }
+
+
+    public function getMenu()
+    {
+        return LaravelMenu::new()
+            ->addClass('sidebar-menu')
+
+            //General
+            ->html('General', ['class'=>'header'])
+            ->add(Link::to(
+                route('admin.dashboard'),
+                self::placeIcon('dashboard', trans('menus.backend.sidebar.dashboard'))
+            ))
+
+            //System
+            ->html(trans('menus.backend.sidebar.system'), ['class'=>'header'])
+            ->submenuIf(
+                access()->hasRole("1"),
+                Link::to(
+                    '#',
+                    self::placeIcon(
+                        'users',
+                        trans('labels.backend.access.users.management')
+                    ) . self::pendingApproval()
+                ),
+                LaravelMenu::new()
+                    ->addClass('treeview-menu')
+                    ->add(Link::to(
+                        route('admin.access.user.index'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('labels.backend.access.users.management')
+                        ) . self::pendingApproval()
+                    ))
+                    ->add(Link::to(
+                        route('admin.access.role.index'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('labels.backend.access.roles.management')
+                        )
+                    ))
+            )
+            ->submenu(
+                Link::to(
+                    '#',
+                    self::placeIcon(
+                        'list',
+                        trans('menus.backend.log-viewer.main')
+                    ) . '<i class="fa fa-angle-left pull-right"></i>'
+                ),
+                LaravelMenu::new()
+                    ->addClass('treeview-menu')
+                    ->add(Link::to(
+                        route('log-viewer::dashboard'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('menus.backend.log-viewer.dashboard')
+                        )
+                    ))
+                    ->add(Link::to(
+                        route('log-viewer::logs.list'),
+                        self::placeIcon(
+                            'circle-o',
+                            trans('menus.backend.log-viewer.logs')
+                        )
+                    ))
+            )->setActive(url()->current());
+    }
+
+    /**
+     * @param string $icon
+     * @param string $text
+     * @return string
+     */
+    private function placeIcon(string $icon, string $text)
+    {
+        return("<i class=\"fa fa-{$icon}\"></i><span>{$text}</span>");
+    }
+
+    /**
+     * @return string
+     */
+    private function pendingApproval()
+    {
+        if ( config('access.users.requires_approval') && $this->userRepository->getUnconfirmedCount() > 0 ) {
+            return "<span class=\"label label-danger pull-right\">{$this->userRepository->getUnconfirmedCount()}</span>";
+        } else {
+            return "<i class=\"fa fa-angle-left pull-right\"></i>";
+        }
+    }
+}

--- a/app/Services/Menu/Menu.php
+++ b/app/Services/Menu/Menu.php
@@ -7,7 +7,7 @@ use Spatie\Menu\Laravel\Menu as LaravelMenu;
 use App\Repositories\Backend\Access\User\UserRepository;
 
 /**
- * Class Menu
+ * Class Menu.
  */
 class Menu
 {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "laravel/socialite": "^3.0",
         "laravel/tinker": "~1.0",
         "laravelcollective/html": "5.4.*",
+        "spatie/laravel-menu": "2.1.*",
         "yajra/laravel-datatables-oracle": "^7.0"
     },
     "require-dev": {

--- a/resources/views/backend/includes/sidebar.blade.php
+++ b/resources/views/backend/includes/sidebar.blade.php
@@ -27,75 +27,7 @@
     <!-- /.search form -->
 
         <!-- Sidebar Menu -->
-        <ul class="sidebar-menu">
-            <li class="header">{{ trans('menus.backend.sidebar.general') }}</li>
-
-            <li class="{{ active_class(Active::checkUriPattern('admin/dashboard')) }}">
-                <a href="{{ route('admin.dashboard') }}">
-                    <i class="fa fa-dashboard"></i>
-                    <span>{{ trans('menus.backend.sidebar.dashboard') }}</span>
-                </a>
-            </li>
-
-            <li class="header">{{ trans('menus.backend.sidebar.system') }}</li>
-
-            @role(1)
-            <li class="{{ active_class(Active::checkUriPattern('admin/access/*')) }} treeview">
-                <a href="#">
-                    <i class="fa fa-users"></i>
-                    <span>{{ trans('menus.backend.access.title') }}</span>
-
-                    @if ($pending_approval > 0)
-                        <span class="label label-danger pull-right">{{ $pending_approval }}</span>
-                    @else
-                        <i class="fa fa-angle-left pull-right"></i>
-                    @endif
-                </a>
-
-                <ul class="treeview-menu {{ active_class(Active::checkUriPattern('admin/access/*'), 'menu-open') }}" style="display: none; {{ active_class(Active::checkUriPattern('admin/access/*'), 'display: block;') }}">
-                    <li class="{{ active_class(Active::checkUriPattern('admin/access/user*')) }}">
-                        <a href="{{ route('admin.access.user.index') }}">
-                            <i class="fa fa-circle-o"></i>
-                            <span>{{ trans('labels.backend.access.users.management') }}</span>
-
-                            @if ($pending_approval > 0)
-                                <span class="label label-danger pull-right">{{ $pending_approval }}</span>
-                            @endif
-                        </a>
-                    </li>
-
-                    <li class="{{ active_class(Active::checkUriPattern('admin/access/role*')) }}">
-                        <a href="{{ route('admin.access.role.index') }}">
-                            <i class="fa fa-circle-o"></i>
-                            <span>{{ trans('labels.backend.access.roles.management') }}</span>
-                        </a>
-                    </li>
-                </ul>
-            </li>
-            @endauth
-
-            <li class="{{ active_class(Active::checkUriPattern('admin/log-viewer*')) }} treeview">
-                <a href="#">
-                    <i class="fa fa-list"></i>
-                    <span>{{ trans('menus.backend.log-viewer.main') }}</span>
-                    <i class="fa fa-angle-left pull-right"></i>
-                </a>
-                <ul class="treeview-menu {{ active_class(Active::checkUriPattern('admin/log-viewer*'), 'menu-open') }}" style="display: none; {{ active_class(Active::checkUriPattern('admin/log-viewer*'), 'display: block;') }}">
-                    <li class="{{ active_class(Active::checkUriPattern('admin/log-viewer')) }}">
-                        <a href="{{ route('log-viewer::dashboard') }}">
-                            <i class="fa fa-circle-o"></i>
-                            <span>{{ trans('menus.backend.log-viewer.dashboard') }}</span>
-                        </a>
-                    </li>
-
-                    <li class="{{ active_class(Active::checkUriPattern('admin/log-viewer/logs')) }}">
-                        <a href="{{ route('log-viewer::logs.list') }}">
-                            <i class="fa fa-circle-o"></i>
-                            <span>{{ trans('menus.backend.log-viewer.logs') }}</span>
-                        </a>
-                    </li>
-                </ul>
-            </li>
-        </ul><!-- /.sidebar-menu -->
+        {!! $menu->render() !!}
+        <!-- /.sidebar-menu -->
     </section><!-- /.sidebar -->
 </aside>


### PR DESCRIPTION
This PR is for an enhancement for the side-bar menu.  Instead of using html and blade this allows the menu to be created with with the spatie/laravel-menu plugin.  All the menu code is neatly packaged into a Menu Service, which allows for even more options to build menu.  Included is the original menu exactly as was, recreated with the plugin.  For information regarding the menu plugin please see.

https://docs.spatie.be/menu/v2/introduction#.