### PR TITLE
Removing unsigned usage with increments

### DIFF
--- a/database/migrations/2015_12_28_171741_create_social_logins_table.php
+++ b/database/migrations/2015_12_28_171741_create_social_logins_table.php
@@ -17,7 +17,7 @@ class CreateSocialLoginsTable extends Migration
     public function up()
     {
         Schema::create('social_logins', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id');
             $table->integer('user_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->string('provider', 32);

--- a/database/migrations/2015_12_29_015055_setup_access_tables.php
+++ b/database/migrations/2015_12_29_015055_setup_access_tables.php
@@ -24,7 +24,7 @@ class SetupAccessTables extends Migration
         });
 
         Schema::create(config('access.roles_table'), function ($table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id');
             $table->string('name');
             $table->boolean('all')->default(false);
             $table->smallInteger('sort')->default(0)->unsigned();
@@ -37,7 +37,7 @@ class SetupAccessTables extends Migration
         });
 
         Schema::create(config('access.role_user_table'), function ($table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id');
             $table->integer('user_id')->unsigned();
             $table->integer('role_id')->unsigned();
 
@@ -56,7 +56,7 @@ class SetupAccessTables extends Migration
         });
 
         Schema::create(config('access.permissions_table'), function ($table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id');
             $table->string('name');
             $table->string('display_name');
             $table->timestamps();
@@ -68,7 +68,7 @@ class SetupAccessTables extends Migration
         });
 
         Schema::create(config('access.permission_role_table'), function ($table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id');
             $table->integer('permission_id')->unsigned();
             $table->integer('role_id')->unsigned();
 

--- a/database/migrations/2016_07_03_062439_create_history_tables.php
+++ b/database/migrations/2016_07_03_062439_create_history_tables.php
@@ -17,13 +17,13 @@ class CreateHistoryTables extends Migration
     public function up()
     {
         Schema::create('history_types', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id');
             $table->string('name');
             $table->timestamps();
         });
 
         Schema::create('history', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id');
             $table->integer('type_id')->unsigned();
             $table->integer('user_id')->unsigned();
             $table->integer('entity_id')->unsigned()->nullable();


### PR DESCRIPTION
Use of unsigned() with increments() is redundant. increments() itself create a auto increment unsigned integer.

refs: ( $table->increments('id');  under Available Column Types )
https://laravel.com/docs/5.5/migrations#creating-columns