### PR TITLE
Added fix when running php artisan in CLI with no APP_KEY.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,10 +38,12 @@ class AppServiceProvider extends ServiceProvider
          * Set the session variable for whether or not the app is using RTL support
          * For use in the blade directive in BladeServiceProvider
          */
-        if (config('locale.languages')[config('app.locale')][2]) {
-            session(['lang-rtl' => true]);
-        } else {
-            session()->forget('lang-rtl');
+        if (! app()->runningInConsole()){
+            if (config('locale.languages')[config('app.locale')][2]) {
+                session(['lang-rtl' => true]);
+            } else {
+                session()->forget('lang-rtl');
+            }
         }
 
         // Force SSL in production

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,7 +38,7 @@ class AppServiceProvider extends ServiceProvider
          * Set the session variable for whether or not the app is using RTL support
          * For use in the blade directive in BladeServiceProvider
          */
-        if (! app()->runningInConsole()){
+        if (! app()->runningInConsole()) {
             if (config('locale.languages')[config('app.locale')][2]) {
                 session(['lang-rtl' => true]);
             } else {


### PR DESCRIPTION
Issue: Laravel generates a RuntimeException in the CLI with encrypted sessions when running `php artisan`. 

    [RuntimeException]                                 
    No application encryption key has been specified.

The fix allows a new key to be generated with 'php artisan key:generate' with no current APP_KEY specified in a new .env file.
