### PR TITLE
Added Boostrap 4 templates as default pagination view

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -56,8 +56,8 @@ class AppServiceProvider extends ServiceProvider
         Schema::defaultStringLength(191);
 
         // Set the default template for Pagination to use the included Bootstrap 4 template
-        \Illuminate\Pagination\AbstractPaginator::defaultView("pagination::bootstrap-4");
-        \Illuminate\Pagination\AbstractPaginator::defaultSimpleView("pagination::simple-bootstrap-4");
+        \Illuminate\Pagination\AbstractPaginator::defaultView('pagination::bootstrap-4');
+        \Illuminate\Pagination\AbstractPaginator::defaultSimpleView('pagination::simple-bootstrap-4');
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -54,6 +54,10 @@ class AppServiceProvider extends ServiceProvider
         // Set the default string length for Laravel5.4
         // https://laravel-news.com/laravel-5-4-key-too-long-error
         Schema::defaultStringLength(191);
+
+        // Set the default template for Pagination to use the included Bootstrap 4 template
+        \Illuminate\Pagination\AbstractPaginator::defaultView("pagination::bootstrap-4");
+        \Illuminate\Pagination\AbstractPaginator::defaultSimpleView("pagination::simple-bootstrap-4");
     }
 
     /**

--- a/resources/views/backend/auth/role/index.blade.php
+++ b/resources/views/backend/auth/role/index.blade.php
@@ -53,9 +53,6 @@
                 </table>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-body-->
-
-    <div class="card-footer">
         <div class="row">
             <div class="col-7">
                 <div class="float-left">
@@ -69,6 +66,6 @@
                 </div>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-footer-->
+    </div><!--card-body-->
 </div><!--card-->
 @endsection

--- a/resources/views/backend/auth/user/deactivated.blade.php
+++ b/resources/views/backend/auth/user/deactivated.blade.php
@@ -56,9 +56,6 @@
                 </table>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-body-->
-
-    <div class="card-footer">
         <div class="row">
             <div class="col-7">
                 <div class="float-left">
@@ -72,6 +69,6 @@
                 </div>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-footer-->
+    </div><!--card-body-->
 </div><!--card-->
 @endsection

--- a/resources/views/backend/auth/user/deleted.blade.php
+++ b/resources/views/backend/auth/user/deleted.blade.php
@@ -57,9 +57,6 @@
                 </table>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-body-->
-
-    <div class="card-footer">
         <div class="row">
             <div class="col-7">
                 <div class="float-left">
@@ -73,6 +70,6 @@
                 </div>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-footer-->
+    </div><!--card-body-->
 </div><!--card-->
 @endsection

--- a/resources/views/backend/auth/user/index.blade.php
+++ b/resources/views/backend/auth/user/index.blade.php
@@ -55,9 +55,6 @@
                 </table>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-body-->
-
-    <div class="card-footer">
         <div class="row">
             <div class="col-7">
                 <div class="float-left">
@@ -71,6 +68,6 @@
                 </div>
             </div><!--col-->
         </div><!--row-->
-    </div><!--card-footer-->
+    </div><!--card-body-->
 </div><!--card-->
 @endsection


### PR DESCRIPTION
Changed the default Laravel AbstractPaginator class to use the built in Bootstrap 4 blade templates.
Moved pagination out of the Bootstrap 'card-footer' as it was causing the pagination to display as table.
