### PR TITLE
Fix for n+1 issue on Backend/Auth/UserRepository.php

### DIFF
--- a/app/Repositories/Backend/Auth/UserRepository.php
+++ b/app/Repositories/Backend/Auth/UserRepository.php
@@ -52,7 +52,7 @@ class UserRepository extends BaseRepository
     public function getActivePaginated($paged = 25, $orderBy = 'created_at', $sort = 'desc') : LengthAwarePaginator
     {
         return $this->model
-            ->with('providers')
+            ->with('roles', 'permissions', 'providers')
             ->active()
             ->orderBy($orderBy, $sort)
             ->paginate($paged);
@@ -68,7 +68,7 @@ class UserRepository extends BaseRepository
     public function getInactivePaginated($paged = 25, $orderBy = 'created_at', $sort = 'desc') : LengthAwarePaginator
     {
         return $this->model
-            ->with('providers')
+            ->with('roles', 'permissions', 'providers')
             ->active(false)
             ->orderBy($orderBy, $sort)
             ->paginate($paged);
@@ -84,7 +84,7 @@ class UserRepository extends BaseRepository
     public function getDeletedPaginated($paged = 25, $orderBy = 'created_at', $sort = 'desc') : LengthAwarePaginator
     {
         return $this->model
-            ->with('providers')
+            ->with('roles', 'permissions', 'providers')
             ->onlyTrashed()
             ->orderBy($orderBy, $sort)
             ->paginate($paged);


### PR DESCRIPTION
On the Backend UserRepository, a user's roles and permissions are queried individually when viewing the Role Management page. This fix eager loads the roles and permissions, reducing number of queries from 57 to 9 on a page with the default 25 paginated users.