### PR TITLE
Fixes google's no captcha validation

### DIFF
--- a/app/Http/Requests/Frontend/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Frontend/Auth/RegisterRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Arcanedev\NoCaptcha\Rules\CaptchaRule;
 use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -32,7 +33,7 @@ class RegisterRequest extends FormRequest
             'last_name'            => 'required|string|max:191',
             'email'                => ['required', 'string', 'email', 'max:191', Rule::unique('users')],
             'password'             => 'required|string|min:6|confirmed',
-            'g-recaptcha-response' => 'required_if:captcha_status,true|captcha',
+            'g-recaptcha-response' => ['required_if:captcha_status,true', new CaptchaRule()],
         ];
     }
 

--- a/config/app.php
+++ b/config/app.php
@@ -246,7 +246,6 @@ return [
          * Package Aliases
          */
         'Active' => HieuLe\Active\Facades\Active::class,
-        'Captcha' => Arcanedev\NoCaptcha\Facades\NoCaptcha::class,
         'Gravatar' => Creativeorange\Gravatar\Facades\Gravatar::class,
         'Socialite' => Laravel\Socialite\Facades\Socialite::class,
 


### PR DESCRIPTION
As soon as you try to submit the registration form with activated NoCaptcha then you'll get an missing member-Exception because NoCaptcha's validation-rule usage for Laravel 5.5 got changed.  Additionally it's not required to register the alias anymore. 