### PR TITLE
Set default avatar_type when registered/logged in via socialite 

### DIFF
--- a/app/Repositories/Frontend/Auth/UserRepository.php
+++ b/app/Repositories/Frontend/Auth/UserRepository.php
@@ -275,7 +275,7 @@ class UserRepository extends BaseRepository
                 'active' => 1,
                 'confirmed' => 1,
                 'password' => null,
-                'avatar' => $provider,
+                'avatar_type' => $provider,
             ]);
 
             event(new UserProviderRegistered($user));

--- a/app/Repositories/Frontend/Auth/UserRepository.php
+++ b/app/Repositories/Frontend/Auth/UserRepository.php
@@ -275,6 +275,7 @@ class UserRepository extends BaseRepository
                 'active' => 1,
                 'confirmed' => 1,
                 'password' => null,
+                'avatar' => $provider,
             ]);
 
             event(new UserProviderRegistered($user));
@@ -295,6 +296,9 @@ class UserRepository extends BaseRepository
                 'token'       => $data->token,
                 'avatar'      => $data->avatar,
             ]);
+
+            $user->avatar_type = $provider;
+            $user->update();
         }
 
         // Return the user object


### PR DESCRIPTION
I was quite irritated why I didn't saw the my providers image. This PR will set the correct avatar_type when a user registers or when he reauthenticates with the provider.