### PR TITLE
Change count() to !empty for scopes, with and fields in SocialLoginCo…

### DIFF
--- a/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
@@ -102,9 +102,9 @@ class SocialLoginController extends Controller
     protected function getAuthorizationFirst($provider)
     {
         $socialite = Socialite::driver($provider);
-        $scopes = count(config("services.{$provider}.scopes")) ? config("services.{$provider}.scopes") : false;
-        $with = count(config("services.{$provider}.with")) ? config("services.{$provider}.with") : false;
-        $fields = count(config("services.{$provider}.fields")) ? config("services.{$provider}.fields") : false;
+        $scopes = !isset(config("services.{$provider}.scopes")) ? config("services.{$provider}.scopes") : false;
+        $with = !isset(config("services.{$provider}.with")) ? config("services.{$provider}.with") : false;
+        $fields = !isset(config("services.{$provider}.fields")) ? config("services.{$provider}.fields") : false;
 
         if ($scopes) {
             $socialite->scopes($scopes);


### PR DESCRIPTION
…ntroller::getAuthorizationFirst().

It was causing a Countable error. Related notes: https://wiki.php.net/rfc/counting_non_countables

# Proposed fix
Fix the countable error in PHP 7.2 where a scalar or object without the Countable interface is being `count()`ed.
