### PR TITLE
Set default timezone form .env when creating new users

### DIFF
--- a/resources/views/backend/auth/user/create.blade.php
+++ b/resources/views/backend/auth/user/create.blade.php
@@ -88,7 +88,7 @@
                             <div class="col-md-10">
                                 <select name="timezone" id="timezone" class="form-control" required="required">
                                     @foreach (timezone_identifiers_list() as $timezone)
-                                        <option value="{{ $timezone }}" {{ $timezone == 'UTC' ? 'selected' : '' }} {{ $timezone == old('timezone') ? ' selected' : '' }}>{{ $timezone }}</option>
+                                        <option value="{{ $timezone }}" {{ $timezone == env("APP_TIMEZONE") ? 'selected' : '' }} {{ $timezone == old('timezone') ? ' selected' : '' }}>{{ $timezone }}</option>
                                     @endforeach
                                 </select>
                             </div><!--col-->


### PR DESCRIPTION
This is an enhancement to preselect the timezone dropdown from the .env file that the user has set up initially instead of "hardcoding" the default to "UTC".