### PR TITLE
move import custom.scss position to allow overide bootstrap more easily

### DIFF
--- a/resources/assets/sass/frontend/app.scss
+++ b/resources/assets/sass/frontend/app.scss
@@ -4,9 +4,6 @@
 // Font Awesome
 @import "../../../../node_modules/font-awesome/scss/font-awesome";
 
-// Bootstrap Overrides
-@import "custom";
-
 // Bootstrap
 @import "../../../../node_modules/bootstrap/scss/bootstrap";
 
@@ -15,5 +12,8 @@
 
 // Pages
 @import "pages/dashboard";
+
+// Bootstrap Overrides
+@import "custom";
 
 // Plugins


### PR DESCRIPTION
This is fix of the position for importing custom.scss to allow override bootstrap more easily. Before this fix, if you want to override some style of bootstrap, you have to use `!important`, which is not desirable. 
