### PR TITLE
Fix not translated "Contact us"

### DIFF
--- a/resources/views/frontend/contact.blade.php
+++ b/resources/views/frontend/contact.blade.php
@@ -1,6 +1,6 @@
 @extends('frontend.layouts.app')
 
-@section('title', app_name() . ' | Contact Us')
+@section('title', app_name() . ' | '.__('labels.frontend.contact.box_title'))
 
 @section('content')
     <div class="row justify-content-center">


### PR DESCRIPTION
Fix not translated "Contact us" in title page