### PR TITLE
Fixes Button Missallignment in BE/UserManagment

### DIFF
--- a/app/Models/Auth/Traits/Attribute/UserAttribute.php
+++ b/app/Models/Auth/Traits/Attribute/UserAttribute.php
@@ -285,7 +285,7 @@ trait UserAttribute
 		  '.$this->show_button.'
 		  '.$this->edit_button.'
 		
-		  <div class="btn-group" role="group">
+		  <div class="btn-group btn-group-sm" role="group">
 			<button id="userActions" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 			  More
 			</button>


### PR DESCRIPTION
added "btn-group-sm" also to the dropdown on the UserManagment page.
So the icons get vertically-centered.
