### PR TITLE
fixed social accounts token length

### DIFF
--- a/database/migrations/2017_09_11_174816_create_social_accounts_table.php
+++ b/database/migrations/2017_09_11_174816_create_social_accounts_table.php
@@ -22,7 +22,7 @@ class CreateSocialAccountsTable extends Migration
             $table->foreign('user_id')->references('id')->on('users');
             $table->string('provider', 32);
             $table->string('provider_id');
-            $table->string('token')->nullable();
+            $table->string('token', 255)->nullable();
             $table->string('avatar')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
The current token length in the social_accounts table are unsufficient for the facebook token lengths. I experienced the issue myself, unfortunately one Facebook app review failed because of this. 

There is no fixed maximum length for the facebook access_token, as facebook [employees stated on StackOverflow](https://stackoverflow.com/questions/4408945/what-is-the-length-of-the-access-token-in-facebook-oauth2) but they advised to 255 characters. That's the best i could find. 

Or do you think it should just be ->text() ? 

(Sorry for the double PR, i overlooked the contribution guidelines)