### PR TITLE
Update repository scopes

### DIFF
--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -479,6 +479,7 @@ abstract class BaseRepository implements RepositoryContract
     public function __call($scope, $args)
     {
         $this->scopes[$scope] = $args;
+        
         return $this;
     }
 }

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -447,7 +447,7 @@ abstract class BaseRepository implements RepositoryContract
     protected function setScopes()
     {
         foreach ($this->scopes as $method => $args) {
-            $this->query->$method(...$args);
+            $this->query->$method(implode(', ', $args));
         }
 
         return $this;
@@ -464,21 +464,6 @@ abstract class BaseRepository implements RepositoryContract
         $this->whereIns = [];
         $this->scopes = [];
         $this->take = null;
-
-        return $this;
-    }
-
-    /**
-     * Add the given query scope.
-     *
-     * @param string $scope
-     * @param array $args
-     *
-     * @return $this
-     */
-    public function __call($scope, $args)
-    {
-        $this->scopes[$scope] = $args;
 
         return $this;
     }

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -447,7 +447,7 @@ abstract class BaseRepository implements RepositoryContract
     protected function setScopes()
     {
         foreach ($this->scopes as $method => $args) {
-            $this->query->$method(implode(', ', $args));
+            $this->query->$method(...$args);
         }
 
         return $this;
@@ -464,6 +464,21 @@ abstract class BaseRepository implements RepositoryContract
         $this->whereIns = [];
         $this->scopes = [];
         $this->take = null;
+
+        return $this;
+    }
+
+    /**
+     * Add the given query scope.
+     *
+     * @param string $scope
+     * @param array $args
+     *
+     * @return $this
+     */
+    public function __call($scope, $args)
+    {
+        $this->scopes[$scope] = $args;
 
         return $this;
     }

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -447,7 +447,7 @@ abstract class BaseRepository implements RepositoryContract
     protected function setScopes()
     {
         foreach ($this->scopes as $method => $args) {
-            $this->query->$method(implode(', ', $args));
+            $this->query->$method(...$args);
         }
 
         return $this;
@@ -465,6 +465,20 @@ abstract class BaseRepository implements RepositoryContract
         $this->scopes = [];
         $this->take = null;
 
+        return $this;
+    }
+
+    /**
+     * Add the given query scope.
+     *
+     * @param string $scope
+     * @param array $args
+     *
+     * @return $this
+     */
+    public function __call($scope, $args)
+    {
+        $this->scopes[$scope] = $args;
         return $this;
     }
 }


### PR DESCRIPTION
This PR adds the magic method __call to the BaseRepository to add query scopes easily to repository queries on the fly. It also replaces implode with the spread operator when setting the scopes because implode was causing all parameters to be sent as one parameter, just comma deliminated. 

Adding the scopes through magic methods makes sense to me since it is more like Eloquent this way, which makes it more intuitive to use.