### PR TITLE
Added `.default` to Vue component requires

### DIFF
--- a/resources/js/frontend/app.js
+++ b/resources/js/frontend/app.js
@@ -20,9 +20,9 @@ window.Vue = Vue;
  */
 
 // const files = require.context('./', true, /\.vue$/i)
-// files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key)))
+// files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
 
-Vue.component('example-component', require('./components/ExampleComponent.vue'));
+Vue.component('example-component', require('./components/ExampleComponent.vue').default);
 
 /**
  * Next, we will create a fresh Vue application instance and attach it to


### PR DESCRIPTION
# Fixes
Instances of `[Vue warn]: Failed to mount component: template or render function not defined.` on default clone of repo. Sorta makes it more consistent with Laravel/Laravel.

This will give support for JeffreyWay/laravel-mix v4.0.0 and up which needs CommonJS syntax for EcmaScript modules.

JeffreyWay mentioned this in the "Breaking" section here: https://github.com/JeffreyWay/laravel-mix/releases/tag/v4.0.0
with a matching commit here: https://github.com/laravel/laravel/commit/dc58f95ebbf15b8902ccaef4e2aaa6b0ecbb0e96
to finally a PR here: https://github.com/laravel/laravel/pull/4882

Note that this has not been persisted to the compiled assets in this PR as it is producing the error fixed in https://github.com/rappasoft/laravel-5-boilerplate/pull/1182.