### PR TITLE
setting resource root

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,6 +13,8 @@ const mix = require('laravel-mix');
 
 mix.setPublicPath('public');
 
+mix.setResourceRoot('../');
+
 mix.sass('resources/sass/frontend/app.scss', 'css/frontend.css')
     .sass('resources/sass/backend/app.scss', 'css/backend.css')
     .js('resources/js/frontend/app.js', 'js/frontend.js')


### PR DESCRIPTION
Currently resources in CSS get loaded only if you host your site on "domain.xy". This will work even if you have your Laravel on "domain.xy/app/public".

Fix found on: https://www.samundra.com.np/integrating-font-awesome-with-laravel-5.x-using-webpack/1574