### PR TITLE
Add jquery validation to backend forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "cross-var": "^1.1.0",
         "jest": "^24.5.0",
         "jquery": "^3.4.1",
+        "jquery-validation": "^1.19.0",
         "laravel-mix": "^4.0.15",
         "lodash": "^4.17.11",
         "pace": "github:HubSpot/pace#v1.0.2",

--- a/resources/js/backend/app.js
+++ b/resources/js/backend/app.js
@@ -1,1 +1,39 @@
 import '@coreui/coreui'
+import 'jquery-validation'
+
+
+jQuery.validator.setDefaults({
+	invalidHandler: function() {
+		var submits = $(this).find('[type="submit"]');
+		submits.attr('disabled', false);
+		$('.nav-tabs a strong.required').remove();
+		$('.tab-content.tab-validate .tab-pane:has(input.is-invalid)').each(function() {
+			var id = $(this).attr('id');
+			$('.nav-tabs,.nav-pills').find('a[href^="#' + id + '"]').append(' <strong class="required text-danger">***</strong> ');
+		});
+	},
+	errorElement: "em",
+	errorPlacement: function errorPlacement(error, element) {
+		error.addClass("invalid-feedback");
+		if (element.prop("type") === "checkbox") {
+		error.insertAfter(element.parent("label"));
+		} else {
+		error.insertAfter(element);
+		}
+	},
+	highlight: function highlight(element) {
+		$(element)
+		.addClass("is-invalid")
+		.removeClass("is-valid");
+	},
+	unhighlight: function unhighlight(element) {
+		$(element)
+		.addClass("is-valid")
+		.removeClass("is-invalid");
+	}
+
+  });
+
+var validator = $('form').not('.no-validate').validate({
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5322,7 +5322,14 @@ jest@^24.5.0:
     import-local "^2.0.0"
     jest-cli "^24.5.0"
 
-jquery@^3.4.1:
+jquery-validation@^1.19.0:
+  version "1.19.0"
+  resolved "https://npm.customd.com/jquery-validation/-/jquery-validation-1.19.0.tgz#0fedf0c0483a030c4fff072398898ac18cfd6e40"
+  integrity sha512-i1ygcs9K9eI0jqQ8fiOZdT0Ofw941YII1zyPQDUkBS8t2G8SoSWz8UUEVT6gV1KvsaBbovtL8YxjLALACR0syQ==
+  dependencies:
+    jquery "^1.7 || ^2.0 || ^3.1"
+
+"jquery@^1.7 || ^2.0 || ^3.1", jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==


### PR DESCRIPTION
# enhancement
Adds jQuery validate: `https://jqueryvalidation.org` to the backend forms with default formatting and handling accross tabs (will add '***' to tabs if form in tabs)

![image](https://user-images.githubusercontent.com/952595/57905238-efe48000-78c9-11e9-9628-f24cb0f7d99b.png)

Forms with a class of `.no-validate` will be ignored