### PR TITLE
Resolve #1589 : Deactivated user can login by requesting password reset

### DIFF
--- a/app/Domains/Auth/Http/Controllers/Frontend/Auth/ResetPasswordController.php
+++ b/app/Domains/Auth/Http/Controllers/Frontend/Auth/ResetPasswordController.php
@@ -2,6 +2,7 @@
 
 namespace App\Domains\Auth\Http\Controllers\Frontend\Auth;
 
+use Auth;
 use App\Domains\Auth\Rules\UnusedPassword;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\ResetsPasswords;
@@ -38,6 +39,11 @@ class ResetPasswordController
      */
     public function redirectPath()
     {
+        //prevents automatic login for inactive users after reset password
+        if(!auth()->user()->active) {
+            Auth::logout();
+            return route('frontend.auth.login');
+        }
         return route(homeRoute());
     }
 

--- a/tests/Feature/Frontend/ResetPasswordTest.php
+++ b/tests/Feature/Frontend/ResetPasswordTest.php
@@ -144,4 +144,20 @@ class ResetPasswordTest extends TestCase
         $this->assertSame($errors->get('password')[0], __('You can not set a password that you have previously used within the last 3 times.'));
         $this->assertTrue(Hash::check(':ZqD~57}1t', $user->fresh()->password));
     }
+
+    /** @test: Tests if inactive users are redirected back to login after password reset */
+    public function inactive_users_reset_pwd_redirect_to_login()
+    {
+        $user = User::factory()->inactive()->create(['email' => 'john@example.com']);
+
+        $token = $this->app->make('auth.password.broker')->createToken($user);
+
+        $response = $this->post('password/reset', [
+                'token' => $token,
+                'email' => 'john@example.com',
+                'password' => ']EqZL4}zBT',
+                'password_confirmation' => ']EqZL4}zBT',
+            ]);
+        $response->assertRedirect(route('frontend.auth.login'));
+    }
 }


### PR DESCRIPTION
Resolve #1589 : Deactivated user can login by requesting password reset.

- Added new conditional in redirectPath function for ResetPasswordController, which redirects user based on their active status
- Developed one new test in ResetPasswordTest File, For testing inactive users redirection after successful reset password attempt.