### PR TITLE
Fixes inactive user logging in via reset password link.

### DIFF
--- a/app/Domains/Auth/Models/User.php
+++ b/app/Domains/Auth/Models/User.php
@@ -11,6 +11,7 @@ use App\Domains\Auth\Notifications\Frontend\VerifyEmail;
 use DarkGhostHunter\Laraguard\Contracts\TwoFactorAuthenticatable;
 use DarkGhostHunter\Laraguard\TwoFactorAuthentication;
 use Database\Factories\UserFactory;
+use DB;
 use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -117,7 +118,16 @@ class User extends Authenticatable implements MustVerifyEmail, TwoFactorAuthenti
      */
     public function sendPasswordResetNotification($token): void
     {
-        $this->notify(new ResetPasswordNotification($token));
+        if($this->isActive()) {
+            $this->notify(new ResetPasswordNotification($token));
+        } else {
+            DB::table('password_resets')->where('email', $this->email)->delete();
+            abort(
+                redirect()
+                    ->route('frontend.auth.login')
+                    ->withFlashDanger(__('Your account has been deactivated.'))
+            );
+        }
     }
 
     /**

--- a/app/Domains/Auth/Models/User.php
+++ b/app/Domains/Auth/Models/User.php
@@ -118,7 +118,7 @@ class User extends Authenticatable implements MustVerifyEmail, TwoFactorAuthenti
      */
     public function sendPasswordResetNotification($token): void
     {
-        if($this->isActive()) {
+        if ($this->isActive()) {
             $this->notify(new ResetPasswordNotification($token));
         } else {
             DB::table('password_resets')->where('email', $this->email)->delete();

--- a/tests/Feature/Frontend/ResetPasswordTest.php
+++ b/tests/Feature/Frontend/ResetPasswordTest.php
@@ -154,7 +154,7 @@ class ResetPasswordTest extends TestCase
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'secret',
-            'active' => 0
+            'active' => 0,
         ]);
 
         $this->post('/password/reset', [


### PR DESCRIPTION
If a user has an inactive account and tries to reset the password it will redirect them to the login page with an error. The notification will not be sent.